### PR TITLE
feat: #5 블로그 유저 회원가입 기능 구현

### DIFF
--- a/module-api/src/main/java/com/study/api/blogUser/controller/BlogUserController.java
+++ b/module-api/src/main/java/com/study/api/blogUser/controller/BlogUserController.java
@@ -1,0 +1,122 @@
+package com.study.api.blogUser.controller;
+
+import com.study.api.blog.service.BlogWithdrawService;
+import com.study.api.blogUser.service.*;
+import com.study.api.config.annotation.AuthenticatedUserId;
+import com.study.common.exception.authentication.EmailAuthenticationException;
+import com.study.domain.blogUser.dto.BlogUserDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+/**
+ * BlogUser 관련 요청을 처리하는 컨트롤러입니다.
+ */
+@RestController
+@RequestMapping("/users")
+@RequiredArgsConstructor
+public class BlogUserController {
+
+    private final BlogUserSignUpService blogUserService;
+    private final SmtpEmailService smtpEmailService;
+    private final BlogUserSignInService signInService;
+    private final BlogUserSignOutService signOutService;
+    private final BlogUserWithdrawService blogUserWithdrawService;
+    private final BlogWithdrawService blogWithdrawService;
+
+    /**
+     * 사용자를 등록합니다.
+     *
+     * @param request 회원가입 요청 정보
+     * @param file 프로필 이미지 파일 (선택 사항)
+     * @return 등록된 사용자의 응답 정보
+     */
+    @Operation(
+            method = "POST",
+            summary = "회원가입",
+            description = "아이디, 비밀번호 등을 입력하고, 프로필 사진을 업로드한 후 이메일 인증을 거쳐 회원가입합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "회원가입 성공"),
+            @ApiResponse(responseCode = "409", description = "존재하는 아이디입니다."),
+            @ApiResponse(responseCode = "409", description = "존재하는 닉네임입니다."),
+            @ApiResponse(responseCode = "409", description = "이미 가입된 이메일입니다."),
+            @ApiResponse(responseCode = "409", description = "존재하는 아이디입니다."),
+            @ApiResponse(responseCode = "401", description = "이메일 인증에 실패했습니다."),
+            @ApiResponse(responseCode = "401", description = "이메일 전송에 실패했습니다."),
+            @ApiResponse(responseCode = "401", description = "비밀번호가 일치하지 않습니다."),
+            @ApiResponse(responseCode = "500", description = "서버 오류"),
+            @ApiResponse(responseCode = "500", description = "S3 업로드에 실패했습니다.")
+    })
+    @PostMapping(consumes = {
+            MediaType.APPLICATION_JSON_VALUE,
+            MediaType.MULTIPART_FORM_DATA_VALUE
+    })
+    public ResponseEntity<BlogUserDto.BlogUserResponse> register(
+            @RequestPart @Valid BlogUserDto.IndividualSignupRequestDto request,
+            @RequestPart(required = false) MultipartFile file
+    ) {
+        boolean isEmailVerified = smtpEmailService.isEmailVerified(request.email());
+        if (!isEmailVerified) {
+            throw new EmailAuthenticationException(request.email());
+        }
+
+        BlogUserDto.BlogUserResponse blogUserResponse = blogUserService.individualGeneralSignUp(request, file);
+        return ResponseEntity.ok(blogUserResponse);
+    }
+
+    /**
+     * 사용자의 회원가입을 위한 인증 코드를 이메일로 전송합니다.
+     *
+     * @param email 인증 코드를 받을 이메일 주소
+     * @return 이메일 전송 성공 여부를 나타내는 ResponseEntity (true: 성공, false: 실패)
+     */
+    @Operation(
+            method = "POST",
+            summary = "인증코드 이메일 전송",
+            description = "입력한 이메일로 숫자로 이루어진 인증코드를 전송합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "인증코드 전송 성공"),
+            @ApiResponse(responseCode = "401", description = "이메일 전송에 실패했습니다.")
+    })
+    @PostMapping("/send-verificationCode")
+    public ResponseEntity<Boolean> sendVerificationCode(@RequestParam String email) {
+        boolean result = smtpEmailService.emailForSignup(email);
+        return ResponseEntity.ok(result);
+    }
+
+    /**
+     * 사용자가 입력한 인증 코드를 검증합니다.
+     *
+     * @param email 인증할 이메일 주소
+     * @param code 사용자가 입력한 인증 코드
+     * @return 인증 코드 검증 결과를 나타내는 ResponseEntity (true: 성공, false: 실패)
+     */
+    @Operation(
+            method = "POST",
+            summary = "인증코드 일치여부 확인",
+            description = "입력한 이메일로 전송된 인증번호와 입력한 인증번호가 일치하는지 확인합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "인증코드 일치 확인 성공"),
+            @ApiResponse(responseCode = "401", description = "이메일 인증에 실패했습니다."),
+            @ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @PostMapping("/send-verificationCode/check")
+    public ResponseEntity<Boolean> checkVerificationCode(@RequestParam String email, @RequestParam String code) {
+        boolean result = smtpEmailService.verifyCode(email, code);
+        return ResponseEntity.ok(result);
+    }
+
+
+
+}

--- a/module-api/src/main/java/com/study/api/blogUser/service/SmtpEmailService.java
+++ b/module-api/src/main/java/com/study/api/blogUser/service/SmtpEmailService.java
@@ -1,0 +1,125 @@
+package com.study.api.blogUser.service;
+
+import com.study.common.exception.ErrorCode;
+import com.study.common.exception.authentication.EmailAuthenticationException;
+import com.study.common.exception.duplicate.EmailDuplicateException;
+import com.study.common.exception.email.EmailSendingException;
+
+import com.study.domain.mapper.bloguser.BlogUserQueryMapper;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+
+/**
+ * SMTP 이메일 서비스를 제공하는 클래스입니다.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SmtpEmailService {
+
+    private final JavaMailSender javaMailSender;
+    private final BlogUserQueryMapper blogUserQueryMapper;
+    private final Map<String, String> verificationCodes = new HashMap<>();
+    private Map<String, Boolean> emailVerificationStatus  = new HashMap<>();
+
+
+    /**
+     * 회원가입을 위한 인증 이메일을 발송합니다.
+     *
+     * @param email 인증 이메일을 받을 이메일 주소
+     * @throws MessagingException      이메일 발송 중 예외가 발생할 경우
+     * @throws EmailDuplicateException 이메일이 이미 존재할 경우
+     */
+    public boolean emailForSignup(String email) {
+
+        if (blogUserQueryMapper.existsBlogUserByEmail(email)) {
+            throw new EmailDuplicateException("이미 존재하는 이메일입니다.");
+        }
+        String verificationCode = generateVerificationCode(email);
+        sendVerificationEmail(email, verificationCode);
+        return true;
+    }
+
+    /**
+     * 인증번호를 생성합니다.
+     *
+     * @param email 인증번호를 받을 이메일 주소
+     * @return 생성된 인증번호
+     */
+    private String generateVerificationCode(String email) {
+        Random random = new Random();
+        String code = String.valueOf(100000 + random.nextInt(900000));
+        verificationCodes.put(email, code);
+        return code;
+    }
+
+    /**
+     * 인증번호를 검증합니다.
+     *
+     * @param email 인증할 이메일 주소
+     * @param code  검증할 인증번호
+     * @return 인증번호가 유효한지 여부
+     */
+    public boolean verifyCode(String email, String code) {
+        String storedCode = verificationCodes.get(email);
+
+        if (storedCode == null || !storedCode.equals(code)) {
+            throw new EmailAuthenticationException(email);
+        }
+        emailVerificationStatus.put(email, true);
+        clearCode(email);
+        return true;
+    }
+
+    /**
+     * 이메일의 인증번호를 삭제합니다.
+     *
+     * @param email 인증번호를 삭제할 이메일 주소
+     */
+    public void clearCode(String email) {
+        verificationCodes.remove(email);
+    }
+
+    /**
+     * 인증 이메일을 생성 및 발송합니다.
+     *
+     * @param email            인증 이메일을 받을 이메일 주소
+     * @param verificationCode 발송할 인증번호
+     * @throws MessagingException 이메일 발송 중 예외가 발생할 경우
+     */
+    private void sendVerificationEmail(String email, String verificationCode) {
+        try {
+            MimeMessage mimeMessage = javaMailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, false, "UTF-8");
+            helper.setFrom("chas369@naver.com");
+            helper.setTo(email);
+            helper.setSubject("회원가입 인증 이메일");
+            helper.setText("회원가입 인증번호는 " + verificationCode + " 입니다.");
+            log.info("email = {}, verificationCode = {}", email, verificationCode);
+            javaMailSender.send(mimeMessage);
+        } catch (MessagingException e) {
+            throw new EmailSendingException(email, ErrorCode.FAIL_SEND_EMAIL);
+        }
+    }
+
+    /**
+     * 주어진 이메일 주소에 대한 인증 여부를 확인합니다.
+     *
+     * @param email 인증 여부를 확인할 이메일 주소
+     * @return 이메일이 인증된 경우 true, 그렇지 않은 경우 false
+     */
+    public boolean isEmailVerified(String email){
+        Boolean isVerified = emailVerificationStatus.get(email);
+        return isVerified != null && isVerified;
+    }
+}

--- a/module-api/src/main/java/com/study/api/config/MailConfig.java
+++ b/module-api/src/main/java/com/study/api/config/MailConfig.java
@@ -1,0 +1,43 @@
+package com.study.api.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+@Configuration
+public class MailConfig {
+
+    @Value("${spring.mail.host}")
+    private String host;
+
+    @Value("${spring.mail.port}")
+    private int port;
+
+    @Value("${spring.mail.username}")
+    private String username;
+
+    @Value("${spring.mail.password}")
+    private String password;
+
+    @Value("${spring.mail.properties.mail.smtp.auth}")
+    private String smtpAuth;
+
+    @Bean
+    public JavaMailSender javaMailSender() {
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+
+        mailSender.setHost(host);
+        mailSender.setPort(port);
+        mailSender.setUsername(username);
+        mailSender.setPassword(password);
+
+        Properties props = mailSender.getJavaMailProperties();
+        props.put("mail.smtp.auth", smtpAuth);
+
+        return mailSender;
+    }
+}

--- a/module-api/src/main/java/com/study/api/config/SpringDocsConfig.java
+++ b/module-api/src/main/java/com/study/api/config/SpringDocsConfig.java
@@ -1,0 +1,48 @@
+package com.study.api.config;
+
+
+import io.swagger.v3.oas.models.*;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SpringDocsConfig {
+
+    @Bean
+    public OpenAPI openAPI() {  // OpenAPI 객체를 생성하고, API 문서의 정보를 설정
+        return new OpenAPI()
+                .info(getApiInfo())
+                .paths(getPaths());
+    }
+
+    private Info getApiInfo() {  // API 문서의 기본 정보를 설정
+        return new Info()
+                .title("API 문서")
+                .version("v1")
+                .description("API 문서 설명")
+                .contact(new Contact()
+                        .email("chas369@naver.com"));
+    }
+
+
+
+    private Paths getPaths() {
+        Paths paths = new Paths();
+
+        paths.addPathItem("/users/send-verificationCode", new PathItem()
+                .post(new Operation().security(null)));
+
+        paths.addPathItem("/users/send-verificationCode/check", new PathItem()
+                .post(new Operation().security(null)));
+
+        paths.addPathItem("/users", new PathItem()
+                .post(new Operation().security(null)));
+
+        return paths;
+    }
+}
+

--- a/module-api/src/main/java/com/study/api/fileUpload/config/StorageConfig.java
+++ b/module-api/src/main/java/com/study/api/fileUpload/config/StorageConfig.java
@@ -1,0 +1,50 @@
+package com.study.api.fileUpload.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * AWS S3 스토리지 구성을 위한 설정 클래스입니다.
+ */
+@Getter
+@Configuration
+public class StorageConfig {
+
+    /**
+     * AWS 계정의 액세스 키입니다.
+     */
+    @Value(("${cloud.aws.credentials.access-key}"))
+    private String accessKey;
+
+    /**
+     * AWS 계정의 시크릿 키입니다.
+     */
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    /**
+     * 사용할 AWS 지역 정보입니다.
+     */
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    /**
+     * Amazon S3 클라이언트 빈을 생성하여 반환합니다.
+     *
+     * @return AmazonS3Client 인스턴스
+     */
+    @Bean
+    public AmazonS3Client amazonS3Client(){
+        BasicAWSCredentials awsCreds = new BasicAWSCredentials(accessKey, secretKey);
+        return (AmazonS3Client) AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(awsCreds))
+                .build();
+    }
+}

--- a/module-api/src/main/java/com/study/api/fileUpload/service/S3Uploader.java
+++ b/module-api/src/main/java/com/study/api/fileUpload/service/S3Uploader.java
@@ -1,0 +1,63 @@
+package com.study.api.fileUpload.service;
+
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.study.common.exception.upload.S3UploadException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.UUID;
+
+
+/**
+ * AWS S3에 파일을 업로드하는 서비스 클래스입니다.
+ */
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class S3Uploader {
+
+    private final AmazonS3Client amazonS3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    /**
+     * 파일을 AWS S3 버킷에 업로드합니다.
+     *
+     * @param file    업로드할 파일
+     * @param dirName S3 버킷 내의 디렉토리 이름
+     * @return 업로드된 파일의 URL
+     * @throws S3UploadException 파일 업로드 중 오류가 발생한 경우
+     */
+    public String upload(MultipartFile file, String dirName) {
+        String fileName = dirName + "/" + UUID.randomUUID() + "_" + file.getOriginalFilename();
+        ObjectMetadata metadata = createObjectMetadata(file);
+
+        try {
+            amazonS3Client.putObject(bucket, fileName, file.getInputStream(), metadata); // 버킷에 업로드
+        } catch (IOException e) {
+            log.error("S3 업로드 실패", e);
+            throw new S3UploadException(fileName);
+        }
+        return amazonS3Client.getUrl(bucket, fileName).toString();
+    }
+
+    /**
+     * 파일의 메타데이터를 생성합니다.
+     *
+     * @param file 메타데이터를 생성할 파일
+     * @return 생성된 파일 메타데이터
+     */
+    private ObjectMetadata createObjectMetadata(MultipartFile file) {
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentLength(file.getSize());
+        metadata.setContentType(file.getContentType());
+        return metadata;
+    }
+}

--- a/module-api/src/main/resources/application-aws.yml
+++ b/module-api/src/main/resources/application-aws.yml
@@ -1,0 +1,16 @@
+cloud:
+  aws:
+    credentials:
+      access-key: ${AWS_ACCESS_KEY}
+      secret-key: ${AWS_SECRET_KEY}
+    s3:
+      bucket: studyprojects3
+    region:
+      static: ap-northeast-2
+    stack:
+      auto: false
+
+default:
+  profile:
+    image:
+      url: https://studyprojects3.s3.ap-northeast-2.amazonaws.com/%EC%82%AC%EC%A7%84.png

--- a/module-api/src/main/resources/application-mail.yml
+++ b/module-api/src/main/resources/application-mail.yml
@@ -1,0 +1,10 @@
+spring:
+  mail:
+    host: smtp.naver.com
+    port: 587
+    username: chas369@naver.com
+    password: ${MAIL_PASSWORD}
+    properties:
+      mail.smtp.auth: true
+      mail.smtp.starttls.enable: true
+    protocol: smtps

--- a/module-api/src/main/resources/application.yml
+++ b/module-api/src/main/resources/application.yml
@@ -1,0 +1,22 @@
+spring:
+  application:
+    name: module-api
+  profiles:
+    include:
+      - mail
+      - aws
+
+
+  datasource:
+    url: jdbc:mysql://localhost:3306/study_project
+    username: root
+    password: ${DB_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+
+  servlet:
+    multipart:
+      enabled: true
+      max-file-size: 10MB
+      max-request-size: 10MB
+

--- a/module-common/src/main/java/com/study/common/exception/authentication/EmailAuthenticationException.java
+++ b/module-common/src/main/java/com/study/common/exception/authentication/EmailAuthenticationException.java
@@ -1,0 +1,18 @@
+package com.study.common.exception.authentication;
+
+import com.study.common.exception.ErrorCode;
+
+/**
+ * 이메일 인증 실패 예외를 나타내는 클래스입니다.
+ */
+public class EmailAuthenticationException extends AuthenticationException {
+
+    /**
+     * 주어진 이메일 주소로 새로운 EmailAuthenticationException을 생성합니다.
+     *
+     * @param email 인증 실패한 이메일 주소
+     */
+    public EmailAuthenticationException(String email) {
+        super(email, ErrorCode.FAIL_AUTHENTICATION_EMAIL);
+    }
+}

--- a/module-common/src/main/java/com/study/common/exception/duplicate/DuplicateException.java
+++ b/module-common/src/main/java/com/study/common/exception/duplicate/DuplicateException.java
@@ -1,0 +1,27 @@
+package com.study.common.exception.duplicate;
+
+import com.study.common.exception.BusinessException;
+import com.study.common.exception.ErrorCode;
+import lombok.Getter;
+
+
+/**
+ * 중복 예외를 나타내는 클래스입니다.
+ */
+@Getter
+public class DuplicateException extends BusinessException {
+
+    private String value;
+
+    /**
+     * 주어진 값과 에러 코드로 새로운 DuplicateException을 생성합니다.
+     *
+     * @param value 중복이 발생한 값
+     * @param errorCode 에러 코드
+     */
+    public DuplicateException(String value, ErrorCode errorCode) {
+        super(errorCode);
+        this.value = value;
+    }
+
+}

--- a/module-common/src/main/java/com/study/common/exception/duplicate/EmailDuplicateException.java
+++ b/module-common/src/main/java/com/study/common/exception/duplicate/EmailDuplicateException.java
@@ -1,0 +1,18 @@
+package com.study.common.exception.duplicate;
+
+import com.study.common.exception.ErrorCode;
+
+/**
+ * 이메일 중복 예외를 나타내는 클래스입니다.
+ */
+public class EmailDuplicateException extends DuplicateException {
+
+    /**
+     * 주어진 이메일 주소로 새로운 EmailDuplicateException을 생성합니다.
+     *
+     * @param email 중복된 이메일 주소
+     */
+    public EmailDuplicateException(String email) {
+        super(email, ErrorCode.DUPLICATE_EMAIL);
+    }
+}

--- a/module-common/src/main/java/com/study/common/exception/duplicate/NickNameDuplicateException.java
+++ b/module-common/src/main/java/com/study/common/exception/duplicate/NickNameDuplicateException.java
@@ -1,0 +1,18 @@
+package com.study.common.exception.duplicate;
+
+import com.study.common.exception.ErrorCode;
+
+/**
+ * 닉네임 중복 예외를 나타내는 클래스입니다.
+ */
+public class NickNameDuplicateException extends DuplicateException {
+
+    /**
+     * 주어진 닉네임으로 새로운 NickNameDuplicateException을 생성합니다.
+     *
+     * @param nickName 중복된 닉네임
+     */
+    public NickNameDuplicateException(String nickName) {
+        super(nickName, ErrorCode.DUPLICATE_NICKNAME);
+    }
+}

--- a/module-common/src/main/java/com/study/common/exception/duplicate/UserIdDuplicateException.java
+++ b/module-common/src/main/java/com/study/common/exception/duplicate/UserIdDuplicateException.java
@@ -1,0 +1,18 @@
+package com.study.common.exception.duplicate;
+
+import com.study.common.exception.ErrorCode;
+
+/**
+ * 사용자 ID 중복 예외를 나타내는 클래스입니다.
+ */
+public class UserIdDuplicateException extends DuplicateException {
+
+    /**
+     * 주어진 사용자 ID로 새로운 UserIdDuplicateException을 생성합니다.
+     *
+     * @param userId 중복된 사용자 ID
+     */
+    public UserIdDuplicateException(final String userId) {
+        super(userId, ErrorCode.DUPLICATE_USERID);
+    }
+}

--- a/module-common/src/main/java/com/study/common/exception/email/EmailException.java
+++ b/module-common/src/main/java/com/study/common/exception/email/EmailException.java
@@ -1,0 +1,19 @@
+package com.study.common.exception.email;
+
+import com.study.common.exception.BusinessException;
+import com.study.common.exception.ErrorCode;
+
+public class EmailException extends BusinessException {
+
+
+    private String value;
+
+    public EmailException(String value, ErrorCode errorCode) {
+        super(errorCode);
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/module-common/src/main/java/com/study/common/exception/email/EmailSendingException.java
+++ b/module-common/src/main/java/com/study/common/exception/email/EmailSendingException.java
@@ -1,0 +1,11 @@
+package com.study.common.exception.email;
+
+import com.study.common.exception.ErrorCode;
+
+public class EmailSendingException extends EmailException{
+
+    public EmailSendingException(String email, ErrorCode errorCode) {
+        super(email, errorCode);
+    }
+
+}

--- a/module-common/src/main/java/com/study/common/exception/match/MatchException.java
+++ b/module-common/src/main/java/com/study/common/exception/match/MatchException.java
@@ -1,0 +1,32 @@
+package com.study.common.exception.match;
+
+import com.study.common.exception.BusinessException;
+import com.study.common.exception.ErrorCode;
+
+/**
+ * 일치하지 않음 예외를 나타내는 클래스입니다.
+ */
+public class MatchException extends BusinessException {
+
+    private String value;
+
+    /**
+     * 주어진 값과 에러 코드로 새로운 MatchException을 생성합니다.
+     *
+     * @param value 일치하지 않은 값
+     * @param errorCode 에러 코드
+     */
+    public MatchException(String value, ErrorCode errorCode) {
+        super(errorCode);
+        this.value = value;
+    }
+
+    /**
+     * 예외 발생 시점의 값을 반환합니다.
+     *
+     * @return 예외 발생 시점의 값
+     */
+    public String getValue() {
+        return value;
+    }
+}

--- a/module-common/src/main/java/com/study/common/exception/match/ValidPasswordException.java
+++ b/module-common/src/main/java/com/study/common/exception/match/ValidPasswordException.java
@@ -1,0 +1,18 @@
+package com.study.common.exception.match;
+
+import com.study.common.exception.ErrorCode;
+
+/**
+ * 비밀번호 확인입력 예외를 나타내는 클래스입니다.
+ */
+public class ValidPasswordException extends MatchException {
+
+    /**
+     * 비밀번호 확인입력 예외를 생성합니다.
+     *
+     * @param password 비밀번호
+     */
+    public ValidPasswordException(String password) {
+        super(password, ErrorCode.NOT_MATCH_PASSWORD);
+    }
+}

--- a/module-common/src/main/java/com/study/common/exception/upload/S3UploadException.java
+++ b/module-common/src/main/java/com/study/common/exception/upload/S3UploadException.java
@@ -1,0 +1,10 @@
+package com.study.common.exception.upload;
+
+
+import com.study.common.exception.ErrorCode;
+
+public class S3UploadException extends UploadException{
+    public S3UploadException(String fileName) {
+        super(fileName, ErrorCode.FAIL_S3_UPLOAD);
+    }
+}

--- a/module-common/src/main/java/com/study/common/exception/upload/UploadException.java
+++ b/module-common/src/main/java/com/study/common/exception/upload/UploadException.java
@@ -1,0 +1,15 @@
+package com.study.common.exception.upload;
+
+
+import com.study.common.exception.BusinessException;
+import com.study.common.exception.ErrorCode;
+
+public class UploadException extends BusinessException {
+
+    private String value;
+
+    public UploadException(String value, ErrorCode errorCode) {
+        super(errorCode);
+        this.value = value;
+    }
+}

--- a/module-common/src/main/resources/application.yml
+++ b/module-common/src/main/resources/application.yml
@@ -1,0 +1,3 @@
+spring:
+  application:
+    name: module-common

--- a/module-domain/src/main/java/com/study/domain/blogUser/dto/BlogUserDto.java
+++ b/module-domain/src/main/java/com/study/domain/blogUser/dto/BlogUserDto.java
@@ -1,0 +1,138 @@
+package com.study.domain.blogUser.dto;
+
+import com.study.domain.blogUser.entity.BlogUser;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Builder;
+
+/**
+ * BlogUser에 대한 데이터 전송 객체(DTO)입니다.
+ */
+public class BlogUserDto {
+
+    /**
+     * BlogUser 회원가입 요청을 위한 DTO입니다.
+     */
+    @Builder
+    public record IndividualSignupRequestDto(
+            /**
+             * 사용자의 ID입니다.
+             */
+            @NotBlank
+            @Pattern(regexp = "^[a-z0-9]{5,15}$", message = "아이디는 5자 이상 15자 이하의 영어 소문자 또는 영어 소문자 + 숫자여야 합니다.")
+            @Schema(description = "사용자의 ID입니다. 5자 이상 15자 이하의 영어 소문자 또는 영어 소문자 + 숫자", example = "user123")
+            String userId,
+
+            /**
+             * 사용자의 비밀번호입니다.
+             */
+            @NotBlank
+            @Pattern(
+                    regexp = "^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>\\/?]).{8,}$",
+                    message = "비밀번호는 영문자, 숫자, 특수문자를 혼용하여 8자 이상이어야 하며, 특정 특수문자는 사용할 수 없습니다."
+            )
+            @Schema(description = "사용자의 비밀번호입니다. 영문자, 숫자, 특수문자를 혼용하여 8자 이상", example = "Password1!")
+            String password,
+
+            /**
+             * 비밀번호 확인 값입니다.
+             */
+            @NotBlank
+            @Schema(description = "비밀번호 확인 값입니다.", example = "Password1!")
+            String validPassword,
+
+            /**
+             * 사용자의 이메일입니다.
+             */
+            @NotBlank
+            @Email
+            @Schema(description = "사용자의 이메일입니다.", example = "chas369@naver.com")
+            String email,
+
+            /**
+             * 사용자의 이름입니다.
+             */
+            @NotBlank
+            @Pattern(regexp = "^[가-힣]{2,}$", message = "이름은 2자 이상의 한글이어야 합니다.")
+            @Schema(description = "사용자의 이름입니다. 2자 이상의 한글", example = "홍길동")
+            String userName,
+
+            /**
+             * 사용자의 닉네임입니다.
+             */
+            @NotBlank
+            @Pattern(regexp = "^[a-zA-Z가-힣]{2,}$", message = "닉네임은 2글자 이상의 한글 또는 영문이어야 합니다.")
+            @Schema(description = "사용자의 닉네임입니다. 2글자 이상의 한글 또는 영문", example = "nickname")
+            String nickname,
+
+            /**
+             * 사용자의 전화번호입니다.
+             */
+            @NotBlank
+            @Pattern(regexp = "^[0-9]{10,11}$", message = "전화번호는 -를 제외하고 10자리 또는 11자리 숫자여야 합니다.")
+            @Schema(description = "사용자의 전화번호입니다. -를 제외한 숫자 10자리 또는 11자리", example = "01012345678")
+            String phoneNumber
+    ) {}
+
+    /**
+     * BlogUser 응답을 위한 DTO입니다.
+     */
+    @Builder
+    public record BlogUserResponse(
+            /**
+             * 사용자의 ID입니다.
+             */
+            @Schema(description = "사용자의 ID입니다.", example = "user123")
+            String userId,
+
+            /**
+             * 사용자의 이메일입니다.
+             */
+            @Schema(description = "사용자의 이메일입니다.", example = "chas369@naver.com")
+            String email,
+
+            /**
+             * 사용자의 이름입니다.
+             */
+            @Schema(description = "사용자의 이름입니다.", example = "홍길동")
+            String userName,
+
+            /**
+             * 사용자의 닉네임입니다.
+             */
+            @Schema(description = "사용자의 닉네임입니다.", example = "nickname")
+            String nickname,
+
+            /**
+             * 사용자의 전화번호입니다.
+             */
+            @Schema(description = "사용자의 전화번호입니다.", example = "01012345678")
+            String phoneNumber,
+
+            /**
+             * 사용자의 프로필 이미지 URL입니다.
+             */
+            @Schema(description = "사용자의 프로필 이미지 URL입니다.", example = "https://example.com/profile.jpg")
+            String profileImageUrl
+    ) {
+        /**
+         * BlogUser 엔티티로부터 BlogUserResponse를 생성합니다.
+         *
+         * @param blogUser BlogUser 엔티티
+         * @return BlogUserResponse 인스턴스
+         */
+        public static BlogUserResponse from(BlogUser blogUser) {
+            return new BlogUserResponse(
+                    blogUser.getUserId(),
+                    blogUser.getEmail(),
+                    blogUser.getUserName(),
+                    blogUser.getNickName(),
+                    blogUser.getPhoneNumber(),
+                    blogUser.getProfileImageUrl()
+            );
+        }
+    }
+
+}

--- a/module-domain/src/main/java/com/study/domain/blogUser/entity/BlogUser.java
+++ b/module-domain/src/main/java/com/study/domain/blogUser/entity/BlogUser.java
@@ -1,0 +1,107 @@
+package com.study.domain.blogUser.entity;
+
+import com.study.domain.blogUser.dto.BlogUserDto;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.time.LocalDateTime;
+
+/**
+ * 블로그 사용자(BlogUser) 엔티티 클래스입니다.
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BlogUser {
+
+    /**
+     * 블로그 사용자 ID (자동 생성).
+     */
+    private long id;
+
+    /**
+     * 사용자의 ID입니다.
+     */
+    private String userId;
+
+    /**
+     * 사용자의 비밀번호입니다.
+     */
+    private String password;
+
+    /**
+     * 사용자의 이메일입니다.
+     */
+    private String email;
+
+    /**
+     * 사용자의 이름입니다.
+     */
+    private String userName;
+
+    /**
+     * 사용자의 닉네임입니다.
+     */
+    private String nickName;
+
+    /**
+     * 사용자의 전화번호입니다.
+     */
+    private String phoneNumber;
+
+    /**
+     * 사용자의 프로필 이미지 URL입니다.
+     */
+    private String profileImageUrl;
+
+    private LocalDateTime created_at;
+    private LocalDateTime updated_at;
+    private LocalDateTime deleted_at;
+
+    /**
+     * BlogUser 인스턴스를 생성하는 생성자입니다.
+     *
+     * @param userId 사용자 ID
+     * @param password 비밀번호
+     * @param email 이메일
+     * @param userName 이름
+     * @param nickName 닉네임
+     * @param phoneNumber 전화번호
+     * @param profileImageUrl 프로필 이미지 URL
+     */
+    @Builder
+    public BlogUser(String userId, String password, String email, String userName, String nickName, String phoneNumber, String profileImageUrl) {
+        this.userId = userId;
+        this.password = password;
+        this.email = email;
+        this.userName = userName;
+        this.nickName = nickName;
+        this.phoneNumber = phoneNumber;
+        this.profileImageUrl = profileImageUrl;
+        this.created_at = LocalDateTime.now();
+        this.updated_at = null;
+        this.deleted_at = null;
+    }
+
+    /**
+     * BlogUserRegistrationRequest DTO와 비밀번호 인코더를 사용하여 새로운 BlogUser를 생성합니다.
+     *
+     * @param registrationRequest 회원가입 요청 DTO
+     * @param encoder 비밀번호 인코더(암호화)
+     * @param profileImageUrl 프로필 이미지 URL
+     * @return 생성된 BlogUser 인스턴스
+     */
+    public static BlogUser of(BlogUserDto.IndividualSignupRequestDto registrationRequest, PasswordEncoder encoder, String profileImageUrl) {
+        return BlogUser.builder()
+                .userId(registrationRequest.userId())
+                .password(encoder.encode(registrationRequest.password()))
+                .userName(registrationRequest.userName())
+                .email(registrationRequest.email())
+                .phoneNumber(registrationRequest.phoneNumber())
+                .profileImageUrl(profileImageUrl)
+                .nickName(registrationRequest.nickname())
+                .build();
+    }
+}

--- a/module-domain/src/main/java/com/study/domain/mapper/bloguser/BlogUserCommandMapper.java
+++ b/module-domain/src/main/java/com/study/domain/mapper/bloguser/BlogUserCommandMapper.java
@@ -1,0 +1,15 @@
+package com.study.domain.mapper.bloguser;
+
+
+import com.study.domain.blogUser.entity.BlogUser;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+@Mapper
+public interface BlogUserCommandMapper {
+
+    long save(@Param("blogUser") BlogUser blogUser);
+
+
+
+}

--- a/module-domain/src/main/java/com/study/domain/mapper/bloguser/BlogUserQueryMapper.java
+++ b/module-domain/src/main/java/com/study/domain/mapper/bloguser/BlogUserQueryMapper.java
@@ -1,0 +1,45 @@
+package com.study.domain.mapper.bloguser;
+
+
+import com.study.domain.blogUser.entity.BlogUser;
+import org.apache.ibatis.annotations.Mapper;
+
+import java.util.Optional;
+
+@Mapper
+public interface BlogUserQueryMapper {
+
+    /**
+     * 주어진 사용자 ID로 블로그 사용자 엔티티를 찾습니다.
+     *
+     * @param userId 찾을 사용자 ID
+     * @return 찾은 블로그 사용자 엔티티의 Optional 객체
+     */
+    Optional<BlogUser> findBlogUserByUserId(String userId);
+
+
+    /**
+     * 주어진 사용자 ID가 존재하는지 확인합니다.
+     *
+     * @param userId 확인할 사용자 ID
+     * @return 사용자 ID 존재 여부
+     */
+    boolean existsByUserId(String userId);
+
+    /**
+     * 주어진 닉네임이 존재하는지 확인합니다.
+     *
+     * @param nickname 확인할 닉네임
+     * @return 닉네임 존재 여부
+     */
+    boolean existsByNickname(String nickname);
+
+    /**
+     * 주어진 이메일로 BlogUser를 찾습니다.
+     *
+     * @param email 찾을 이메일
+     * @return 유저 존재 여부
+     */
+    boolean existsBlogUserByEmail(String email);
+
+}

--- a/module-domain/src/main/java/com/study/domain/mapper/config/DBConfig.java
+++ b/module-domain/src/main/java/com/study/domain/mapper/config/DBConfig.java
@@ -1,0 +1,62 @@
+package com.study.domain.mapper.config;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import lombok.RequiredArgsConstructor;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.mybatis.spring.SqlSessionFactoryBean;
+import org.mybatis.spring.SqlSessionTemplate;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+
+import javax.sql.DataSource;
+
+@Configuration
+@RequiredArgsConstructor
+@PropertySource("classpath:/application.yml")
+public class DBConfig {
+    private final ApplicationContext applicationContext;
+
+    @Value("${spring.datasource.url}")
+    private String jdbcUrl;
+
+    @Value("${spring.datasource.username}")
+    private String username;
+
+    @Value("${spring.datasource.password}")
+    private String password;
+
+
+    @Bean
+    public DataSource dataSource() {
+        HikariConfig hikariConfig = new HikariConfig();
+        hikariConfig.setJdbcUrl(jdbcUrl);
+        hikariConfig.setUsername(username);
+        hikariConfig.setPassword(password);
+
+        return new HikariDataSource(hikariConfig);
+    }
+
+    @Bean
+    public SqlSessionFactory sqlSessionFactory() throws Exception {
+        SqlSessionFactoryBean factoryBean = new SqlSessionFactoryBean();
+        factoryBean.setDataSource(dataSource());
+        factoryBean.setMapperLocations(applicationContext.getResources("classpath:/mybatis/mapper/**/*Mapper.xml"));
+        factoryBean.setTypeAliasesPackage("com.study.domain");
+        factoryBean.setConfiguration(mybatisConfig());
+        return factoryBean.getObject();
+    }
+
+    @Bean
+    public SqlSessionTemplate sqlSession() throws Exception {
+        return new SqlSessionTemplate(sqlSessionFactory());
+    }
+
+    @Bean
+    public org.apache.ibatis.session.Configuration mybatisConfig() {
+        return new org.apache.ibatis.session.Configuration();
+    }
+}

--- a/module-domain/src/main/resources/application-rdb.yml
+++ b/module-domain/src/main/resources/application-rdb.yml
@@ -1,0 +1,6 @@
+spring:
+  datasource:
+    url: jdbc:mysql://localhost:3306/study_project
+    username: root
+    password: ${DB_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver

--- a/module-domain/src/main/resources/application.yml
+++ b/module-domain/src/main/resources/application.yml
@@ -1,0 +1,7 @@
+spring:
+  application:
+    name: module-domain
+  profiles:
+    include:
+      - rdb
+

--- a/module-domain/src/main/resources/mybatis/mapper/blogUser/BlogUserCommandMapper.xml
+++ b/module-domain/src/main/resources/mybatis/mapper/blogUser/BlogUserCommandMapper.xml
@@ -1,0 +1,33 @@
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.study.domain.mapper.bloguser.BlogUserCommandMapper">
+
+
+    <sql id="BlogUserColumns">
+        userId,
+        password,
+        email,
+        userName,
+        nickName,
+        phoneNumber,
+        profileImageUrl
+    </sql>
+
+    <insert id="save" parameterType="com.study.domain.blogUser.entity.BlogUser">
+
+        <selectKey resultType="long" keyProperty="id" order="AFTER">
+            SELECT LAST_INSERT_ID()
+        </selectKey>
+
+        insert into bloguser (<include refid="BlogUserColumns"/>)
+        values (
+        #{blogUser.userId},
+        #{blogUser.password},
+        #{blogUser.email},
+        #{blogUser.userName},
+        #{blogUser.nickName},
+        #{blogUser.phoneNumber},
+        #{blogUser.profileImageUrl}
+        )
+    </insert>
+
+</mapper>

--- a/module-domain/src/main/resources/mybatis/mapper/blogUser/BlogUserQueryMapper.xml
+++ b/module-domain/src/main/resources/mybatis/mapper/blogUser/BlogUserQueryMapper.xml
@@ -1,0 +1,26 @@
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.study.domain.mapper.bloguser.BlogUserQueryMapper">
+
+    <!-- 사용자 ID로 블로그 사용자 조회 -->
+    <select id="findBlogUserByUserId" parameterType="String" resultType="com.study.domain.blogUser.entity.BlogUser">
+        SELECT * FROM bloguser WHERE userId = #{userId}
+    </select>
+
+    <!-- 사용자 ID 존재 여부 확인 -->
+    <select id="existsByUserId" parameterType="String" resultType="boolean">
+        SELECT EXISTS(SELECT 1 FROM bloguser WHERE userId = #{userId})
+    </select>
+
+    <!-- 닉네임 존재 여부 확인 -->
+    <select id="existsByNickname" parameterType="String" resultType="boolean">
+        SELECT EXISTS(SELECT 1 FROM bloguser WHERE nickname = #{nickname})
+    </select>
+
+    <!-- 이메일 존재 여부 확인 -->
+    <select id="existsBlogUserByEmail" parameterType="String" resultType="boolean">
+        SELECT EXISTS(SELECT 1 FROM bloguser WHERE email = #{email})
+    </select>
+
+
+
+</mapper>

--- a/module-domain/src/main/resources/mybatis/mybatis-config.xml
+++ b/module-domain/src/main/resources/mybatis/mybatis-config.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE configuration PUBLIC "-//mybatis.org//DTD Config 3.0//EN" "http://mybatis.org/dtd/mybatis-3-config.dtd">
+
+<configuration>
+    <settings>
+        <setting name="mapUnderscoreToCamelCase" value="true"/>
+        <setting name="cacheEnabled" value="false"/>   <!-- Mybatis의 cache 기능은 설정하지 않으면 기본이 on 상태입니다. -->
+        <setting name="localCacheScope" value="STATEMENT"/>
+    </settings>
+
+</configuration>


### PR DESCRIPTION
### 어떤 기능인가요?
- 블로그 유저의 회원가입 기능 구현

### 작업 내용 요약
- [x] 회원의 프로필 이미지를 S3에 저장한다. 회원이 이미지를 등록하지 않으면 기본으로 설정해놓은 이미지를 사용한다.
- [x] SMTP를 사용하며 무작위의 인증번호를 생성해서 이메일을 전송한다.
- [x] 아이디, 비밀번호, 이메일, 닉네임 입력 등에 관한 예외처리 클래스를 생성한다,
- [x] 유저에 관한 entity, service, controller, dto 클래스를 생성한다.
- [x] 데이터베이스, 마이바티스, SMTP, AWS 설정에 관한 yml, xml 파일을 생성한다.
- [x] 데이터베이스, 마이바티스, SMTP, AWS  설정에 관한 config 파일을 생성한다., 

### 작업 상세 내용
> 
1. 회원가입과 관련된 ErrorCode를 생성한다.
![image](https://github.com/user-attachments/assets/680a8dd4-77ea-4d12-b2d5-d2d473c94a13)

2. 회원가입과 관련된 mybatis 파일을 생성한다. 회원을 조회하는 코드와 생성, 수정, 삭제하는 코드의 파일을 나누었다.
- 회원을 찾거나 존재여부를 찾는 메서드 코드는 BlogUserQueryMapper에 있다.
![image](https://github.com/user-attachments/assets/6c194e9d-a15f-47da-a815-7f9436d08c28)
![image](https://github.com/user-attachments/assets/9ab5994c-f658-4a9a-bffb-51b00b86e5f1)



- 회원을 생성(저장) 하는 메서드는 BlogUserCommandMapper에 있다.
![image](https://github.com/user-attachments/assets/5f3b3012-0782-4754-a922-6da1de159576)
![image](https://github.com/user-attachments/assets/411da17c-4f53-4379-b269-7301df0f3a2b)


3. 회원의 프로필 이미지를 S3에 저장한다. 회원이 이미지를 등록하지 않으면 기본으로 설정한 이미지를 사용한다.
- S3를 사용하기위해 AWS key 등을 설정한다. 그리고  기본 이미지가 저장된 링크도 입력해둔다.
![image](https://github.com/user-attachments/assets/b6a1c622-32f1-4dd8-bb71-94785377d89a)

- S3에 파일을 업로드하는 코드이다. 저장되는 파일명은  **UUID_파일명** 이다.
![image](https://github.com/user-attachments/assets/a5e335d2-2a57-4db9-af29-de9d55e8cec5)


5. SMTP를 사용하며 무작위의 인증번호를 생성해서 이메일을 전송한다. 
![image](https://github.com/user-attachments/assets/d41e4b2c-ce36-494d-9d6c-ebbe10664bce)
![image](https://github.com/user-attachments/assets/1f442eab-b9b6-41ba-b505-e77be8a27359)

- 이메일 전송 메서드이다. 하나의 이메일로 인증하고 회원가입했다면, 다음에는 해당 이메일을 사용해서 회원가입을 할 수 없다.
![image](https://github.com/user-attachments/assets/776e8ecb-dc4d-476e-8495-08a4da1c3a80)
![image](https://github.com/user-attachments/assets/117ebcb9-d545-412e-b42c-2519a28a3d90)


- 무작위의 인증번호를 생성하는 메서드와 인증코드를 입력하고 일치하는지 확인하는 메서드이다. 인증코드와 인증여부는 HashMap에 저장한다.
![image](https://github.com/user-attachments/assets/4673c784-66b2-4976-bfe9-0ada3aa48dcc)
![image](https://github.com/user-attachments/assets/8a55505e-f044-4073-b16c-0e10e3203226)

- 사용한 인증번호를 재사용 할 수 없게 제거하는 메서드이다. 
![image](https://github.com/user-attachments/assets/1617519b-3880-41a5-8d6c-73cc2ae04a5d)

- 생성한 인증번호를 메일로 전송하는데에 사용되는 메서드이다.
![image](https://github.com/user-attachments/assets/b8ed55bd-82ed-4cbd-a56b-234668300c4b)