### PR TITLE
feat: #7 블로그 유저 로그인 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,61 @@
+plugins {
+    id 'java'
+    id 'org.springframework.boot' version '3.3.4'
+    id 'io.spring.dependency-management' version '1.1.6'
+}
+
+bootJar.enabled = false
+
+subprojects {
+    group 'com.study'
+    version '0.0.1-SNAPSHOT'
+    sourceCompatibility = '21'
+
+    apply plugin: 'java'
+    apply plugin: 'java-library'
+    apply plugin: 'org.springframework.boot'
+    apply plugin: 'io.spring.dependency-management'
+
+    configurations {
+        compileOnly {
+            extendsFrom annotationProcessor
+        }
+    }
+
+    java {
+        toolchain {
+            languageVersion = JavaLanguageVersion.of(21)
+        }
+    }
+
+    repositories {
+        mavenCentral()
+    }
+
+    dependencies {
+        //lombok
+        implementation 'org.projectlombok:lombok'
+        annotationProcessor 'org.projectlombok:lombok'
+        testImplementation 'org.projectlombok:lombok'
+        testAnnotationProcessor 'org.projectlombok:lombok'
+
+        //validation
+        implementation 'org.springframework.boot:spring-boot-starter-validation:3.3.0'
+
+        //spring web
+        implementation 'org.springframework.boot:spring-boot-starter-web'
+        testImplementation 'org.springframework.boot:spring-boot-starter-web'
+
+        //anotationProcessor
+        annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
+
+        //test
+        testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    }
+
+    tasks.named('test') {
+        useJUnitPlatform()
+    }
+}
+
+

--- a/module-api/build.gradle
+++ b/module-api/build.gradle
@@ -69,6 +69,10 @@ dependencies {
 	testImplementation 'org.junit.jupiter:junit-jupiter:5.7.0'
 	testImplementation 'org.mockito:mockito-core:3.6.28'
 	testImplementation 'org.mockito:mockito-junit-jupiter:3.6.28'
+
+	// swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+
 	// Mockito
 	testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
 	testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.2'

--- a/module-api/build.gradle
+++ b/module-api/build.gradle
@@ -35,6 +35,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	testImplementation 'org.springframework.boot:spring-boot-starter-web'
 
+	//security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 
 	// 파일 업로드를 위한 의존성 추가
@@ -55,6 +58,17 @@ dependencies {
 	implementation 'commons-fileupload:commons-fileupload:1.4'
 
 
+	//jwt
+	implementation("io.jsonwebtoken:jjwt-api:0.11.5")
+	runtimeOnly("io.jsonwebtoken:jjwt-impl:0.11.5")
+	implementation("io.jsonwebtoken:jjwt-jackson:0.11.5")
+	testImplementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	testImplementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	testImplementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+	testImplementation 'org.junit.jupiter:junit-jupiter:5.7.0'
+	testImplementation 'org.mockito:mockito-core:3.6.28'
+	testImplementation 'org.mockito:mockito-junit-jupiter:3.6.28'
 	// Mockito
 	testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
 	testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.2'

--- a/module-api/src/main/java/com/study/api/ModuleApiApplication.java
+++ b/module-api/src/main/java/com/study/api/ModuleApiApplication.java
@@ -1,0 +1,15 @@
+package com.study.api;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication(scanBasePackages = {
+        "com.study.common", "com.study.domain", "com.study.api"
+})
+public class ModuleApiApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(ModuleApiApplication.class, args);
+    }
+
+}

--- a/module-api/src/main/java/com/study/api/blogUser/controller/BlogUserController.java
+++ b/module-api/src/main/java/com/study/api/blogUser/controller/BlogUserController.java
@@ -117,6 +117,31 @@ public class BlogUserController {
         return ResponseEntity.ok(result);
     }
 
+    /**
+     * 사용자 로그인 요청을 처리합니다.
+     *
+     * @param request 로그인 요청 정보
+     * @param response HTTP 응답 객체
+     * @return 로그인 성공 시 빈 응답
+     */
+    @Operation(
+            method = "POST",
+            summary = "로그인",
+            description = "사용자의 아이디와 비밀번호를 입력하여 로그인합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "로그인 성공"),
+            @ApiResponse(responseCode = "401", description = "비밀번호가 일치하지 않습니다."),
+            @ApiResponse(responseCode = "404", description = "유저가 존재하지 않습니다.")
+    })
+    @PostMapping("/login")
+    public ResponseEntity<Void> signIn(
+            @RequestBody @Valid BlogUserDto.BlogUserSignInRequestDto request,
+            HttpServletResponse response
+    ) {
+        signInService.signIn(response, request);
+        return ResponseEntity.noContent().build();
+    }
 
 
 }

--- a/module-api/src/main/java/com/study/api/blogUser/service/BlogUserSignInService.java
+++ b/module-api/src/main/java/com/study/api/blogUser/service/BlogUserSignInService.java
@@ -1,0 +1,136 @@
+package com.study.api.blogUser.service;
+
+import com.study.api.jwt.JwtProperties;
+import com.study.api.jwt.JwtTokenProvider;
+import com.study.api.jwt.TokenType;
+
+import com.study.common.exception.user.NotFoundUserException;
+import com.study.common.utill.CookieUtil;
+import com.study.domain.blogUser.dto.BlogUserDto;
+import com.study.domain.blogUser.entity.BlogUser;
+import com.study.domain.mapper.bloguser.BlogUserQueryMapper;
+import com.study.domain.redis.CookieProperties;
+import com.study.domain.redis.refreshToken.entity.RefreshToken;
+import com.study.domain.redis.refreshToken.repository.RefreshTokenCommand;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+
+/**
+ * 사용자 로그인 요청을 처리하는 서비스입니다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class BlogUserSignInService {
+
+    private final BlogUserQueryMapper blogUserQueryMapper;
+    private final PasswordEncoder passwordEncoder;
+    private final AuthenticationManagerBuilder authenticationManagerBuilder;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final JwtProperties jwtProperties;
+    private final RefreshTokenCommand refreshTokenCommand;
+    private final CookieProperties cookieProperties;
+
+
+    /**
+     * 사용자의 로그인 요청을 처리합니다.
+     *
+     * @param response   HTTP 응답 객체
+     * @param requestDto 로그인 요청 정보
+     */
+    public void signIn(
+            HttpServletResponse response,
+            BlogUserDto.BlogUserSignInRequestDto requestDto
+    ) {
+        BlogUser blogUser = blogUserQueryMapper.findBlogUserByUserId(requestDto.userId()).orElseThrow(() -> new NotFoundUserException(requestDto.userId()));
+
+        if (blogUser.getDeleted_at() != null){
+            throw new NotFoundUserException(requestDto.userId());
+        }
+
+        if (passwordEncoder.matches(requestDto.password(), blogUser.getPassword())) {
+            Authentication authenticate = authenticateUser(requestDto.userId(), requestDto.password());
+
+            String accessTokenValue = createAccessToken(authenticate);
+            String refreshTokenValue = createRefreshToken();
+
+            saveRefreshToken(authenticate.getName(), refreshTokenValue);
+            addTokenCookie(response, TokenType.REFRESH, refreshTokenValue, jwtProperties.getRefreshTokenValidTime());
+            response.setHeader("Authorization", accessTokenValue);
+            log.info("accessTokenValue = {}", accessTokenValue);
+            log.info("refreshTokenValue = {}", refreshTokenValue);
+        }
+    }
+
+    /**
+     * 사용자를 인증합니다.
+     *
+     * @param userId   사용자 ID
+     * @param password 사용자 비밀번호
+     * @return 인증된 사용자 정보
+     */
+    private Authentication authenticateUser(String userId, String password) {
+        return authenticationManagerBuilder.getObject()
+                .authenticate(new UsernamePasswordAuthenticationToken(userId, password));
+    }
+
+    /**
+     * Access Token을 생성합니다.
+     *
+     * @param authentication 인증 정보
+     * @return 생성된 Access Token 값
+     */
+    private String createAccessToken(Authentication authentication) {
+        return jwtTokenProvider.createAccessToken(authentication);
+    }
+
+    /**
+     * Refresh Token을 생성합니다.
+     *
+     * @return 생성된 Refresh Token 값
+     */
+    private String createRefreshToken() {
+        return jwtTokenProvider.createRefreshToken();
+    }
+
+    /**
+     * Refresh Token을 저장합니다.
+     *
+     * @param userId     사용자 ID
+     * @param tokenValue Refresh Token 값
+     */
+    private void saveRefreshToken(String userId, String tokenValue) {
+        refreshTokenCommand.save(new RefreshToken(userId, tokenValue));
+    }
+
+    /**
+     * 토큰을 쿠키에 추가합니다.
+     *
+     * @param response      HTTP 응답 객체
+     * @param tokenType     토큰 타입 (ACCESS, REFRESH)
+     * @param tokenValue    토큰 값
+     * @param tokenLifeTime 토큰 유효 기간
+     */
+    private void addTokenCookie(
+            HttpServletResponse response,
+            TokenType tokenType,
+            String tokenValue,
+            long tokenLifeTime
+    ) {
+        CookieUtil.addCookie(
+                response,
+                tokenType.name(), // 쿠키이름
+                tokenValue,  // 쿠키 값
+                tokenLifeTime,
+                cookieProperties.getDomain(),
+                cookieProperties.getSameSite()
+        );
+    }
+}

--- a/module-api/src/main/java/com/study/api/blogUser/service/CustomUserDetailService.java
+++ b/module-api/src/main/java/com/study/api/blogUser/service/CustomUserDetailService.java
@@ -1,0 +1,51 @@
+package com.study.api.blogUser.service;
+
+import com.study.api.permission.service.PermissionService;
+import com.study.common.exception.user.NotFoundUserException;
+import com.study.domain.blog.entity.Blog;
+import com.study.domain.blogUser.entity.BlogUser;
+import com.study.domain.mapper.blog.BlogQueryMapper;
+import com.study.domain.mapper.bloguser.BlogUserQueryMapper;
+import com.study.domain.permission.entity.UserRole;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+
+import static org.springframework.security.core.userdetails.User.builder;
+
+/**
+ * 사용자 세부 정보를 로드하는 서비스를 구현한 클래스입니다. 사용자가 인증을 요청할 때 사용됩니다.
+ */
+@Component
+@RequiredArgsConstructor
+public class CustomUserDetailService implements UserDetailsService {
+
+    private final BlogQueryMapper blogQueryMapper;
+    private final BlogUserQueryMapper userQueryMapper;
+    private final PermissionService permissionService;
+
+    /**
+     * 사용자 ID를 통해 사용자의 세부 정보를 로드합니다.
+     *
+     * @param userId 사용자 ID
+     * @return 사용자 세부 정보
+     * @throws UsernameNotFoundException 사용자 ID에 해당하는 사용자가 없을 경우
+     */
+    @Override
+    public UserDetails loadUserByUsername(String userId) throws UsernameNotFoundException {
+        BlogUser user = userQueryMapper.findBlogUserByUserId(userId).orElseThrow(() -> new NotFoundUserException(userId));
+        Blog blog = blogQueryMapper.findBlogByUserId(user.getUserId());
+        UserRole userRole = permissionService.getUserRoleForBlog(blog.getId(), userId);
+
+        return builder()
+                .username(user.getUserId())
+                .password(user.getPassword())
+                .authorities(Collections.singletonList(new SimpleGrantedAuthority(userRole.name())))
+                .build();
+    }
+}

--- a/module-api/src/main/java/com/study/api/config/CorsMvcConfig.java
+++ b/module-api/src/main/java/com/study/api/config/CorsMvcConfig.java
@@ -1,0 +1,15 @@
+package com.study.api.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsMvcConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry corsRegistry) {
+        corsRegistry.addMapping("/**")
+                .allowedOrigins("http://localhost:3000");
+    }
+}

--- a/module-api/src/main/java/com/study/api/config/SecurityConfig.java
+++ b/module-api/src/main/java/com/study/api/config/SecurityConfig.java
@@ -1,0 +1,91 @@
+package com.study.api.config;
+
+
+import com.study.api.jwt.filter.JwtTokenFilter;
+import com.study.api.jwt.handler.JwtAccessDeniedHandler;
+import com.study.api.jwt.handler.JwtAuthenticationEntryPointHandler;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+
+import java.util.Collections;
+
+
+/**
+ * Spring Security 설정 클래스입니다.
+ */
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+    private final JwtAuthenticationEntryPointHandler jwtAuthenticationEntryPoint;
+    private final JwtTokenFilter jwtTokenFilter;
+
+    /**
+     * 비밀번호를 암호화하기 위한 {@link PasswordEncoder} 빈을 생성합니다.
+     *
+     * @return 비밀번호 암호화를 위한 {@link BCryptPasswordEncoder} 객체
+     */
+    @Bean
+    public PasswordEncoder getPasswordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    /**
+     * Spring Security 필터 체인을 구성합니다.
+     *
+     * @param http {@link HttpSecurity} 객체
+     * @return 구성된 {@link SecurityFilterChain} 객체
+     * @throws Exception 설정 중 오류가 발생한 경우
+     */
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .authorizeRequests()
+                .anyRequest().permitAll()
+                .and()
+                .csrf(csrf -> csrf.disable())
+                .addFilterBefore(jwtTokenFilter, UsernamePasswordAuthenticationFilter.class)
+                .exceptionHandling(exceptionHandling -> exceptionHandling
+                        .accessDeniedHandler(jwtAccessDeniedHandler)
+                        .authenticationEntryPoint(jwtAuthenticationEntryPoint)
+                );
+
+        http .sessionManagement((session) -> session
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+        http
+                .cors((corsCutomizer -> corsCutomizer.configurationSource(new CorsConfigurationSource() {
+                    @Override
+                    public CorsConfiguration getCorsConfiguration(HttpServletRequest request) {
+                        CorsConfiguration configuration = new CorsConfiguration();
+
+                        configuration.setAllowedOrigins(Collections.singletonList("http://loclahost3000"));
+                        configuration.setAllowedMethods(Collections.singletonList("*"));
+                        configuration.setAllowCredentials(true);
+                        configuration.setAllowedHeaders(Collections.singletonList("*"));
+                        configuration.setMaxAge(3600L);
+
+                        configuration.setExposedHeaders(Collections.singletonList("Authorization"));
+
+                        return configuration;
+                    }
+                })));
+
+
+        return http.build();
+    }
+
+}

--- a/module-api/src/main/java/com/study/api/jwt/JwtProperties.java
+++ b/module-api/src/main/java/com/study/api/jwt/JwtProperties.java
@@ -1,0 +1,34 @@
+package com.study.api.jwt;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+
+/**
+ * JWT 설정을 관리하는 클래스입니다.
+ */
+@Component
+@Getter
+public class JwtProperties {
+
+
+    @Value("${jwt.secret}")
+    private String secretKey;
+
+    @Value("${jwt.token-validity-in-seconds}")
+    private Long accessTokenValidTime;
+
+    @Value("${jwt.refresh-token-validity-in-seconds}")
+    private Long refreshTokenValidTime;
+
+    @Value("${jwt.jwt-issuer}")
+    private String issuer;
+
+    @Value("${jwt.token-start-with}")
+    private String tokenPrefix;
+
+    @Value("${jwt.header}")
+    private String header;
+
+}

--- a/module-api/src/main/java/com/study/api/jwt/JwtTokenParser.java
+++ b/module-api/src/main/java/com/study/api/jwt/JwtTokenParser.java
@@ -1,0 +1,112 @@
+package com.study.api.jwt;
+
+import com.study.domain.redis.refreshToken.repository.RefreshTokenQuery;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.JwtParser;
+import io.jsonwebtoken.Jwts;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.stream.Collectors;
+
+
+/**
+ * JWT 토큰을 파싱하고 인증 정보를 추출하는 클래스입니다.
+ */
+@Component
+public class JwtTokenParser {
+
+
+    private final RefreshTokenQuery refreshTokenQuery;
+    private final JwtParser jwtParser;
+
+    /**
+     * JwtTokenParser 생성자.
+     *
+     * @param jwtProperties JWT 설정 정보
+     * @param refreshTokenQuery 리프레시 토큰 조회 서비스
+     */
+    public JwtTokenParser(
+            RefreshTokenQuery refreshTokenQuery,
+            JwtProperties jwtProperties
+            ) {
+        this.refreshTokenQuery = refreshTokenQuery;
+        this.jwtParser = Jwts.parserBuilder().setSigningKey(jwtProperties.getSecretKey()).build();
+    }
+
+    /**
+     * JWT 토큰에서 인증 정보를 추출합니다.
+     *
+     * @param token JWT 토큰
+     * @return 인증 정보
+     */
+        public Authentication extractAuthentication(String token) {
+        try {
+            Claims claims = jwtParser.parseClaimsJws(token).getBody();
+            Collection<? extends GrantedAuthority> authorities =
+                    Arrays.stream(claims.get(JwtTokenProvider.AUTHORITIES_KEY).toString().split(JwtTokenProvider.AUTHORITIES_DELIMITER))
+                            .map(SimpleGrantedAuthority::new)
+                            .collect(Collectors.toList());
+
+            UserDetails principal = User.builder()
+                    .username(claims.getSubject())
+                    .password("N/A")
+                    .authorities(authorities)
+                    .build();
+            return new UsernamePasswordAuthenticationToken(principal, token, authorities);
+        } catch (JwtException | IllegalArgumentException | NullPointerException exception) {
+            throw new BadCredentialsException(exception.getMessage());
+        }
+    }
+
+
+    /**
+     * 액세스 토큰이 유효한지 검증합니다.
+     *
+     * @param token 액세스 토큰
+     * @return 유효한 경우 true, 그렇지 않은 경우 false
+     */
+    public boolean validateAccessToken(String token) {
+        return validateToken(token, TokenType.ACCESS);
+    }
+
+    /**
+     * 리프레시 토큰이 유효한지 검증합니다.
+     *
+     * @param token 리프레시 토큰
+     * @return 유효한 경우 true, 그렇지 않은 경우 false
+     */
+    public boolean validateRefreshToken(String token) {
+        return refreshTokenQuery.existsByValue(token) && validateToken(token, TokenType.REFRESH);
+    }
+
+
+    /**
+     * 토큰이 유효한지 검증합니다.
+     *
+     * @param token JWT 토큰
+     * @param tokenType 토큰 타입
+     * @return 유효한 경우 true, 그렇지 않은 경우 false
+     */
+    private boolean validateToken(String token, TokenType tokenType) {
+        try {
+            Claims claims = jwtParser.parseClaimsJws(token).getBody();
+            boolean isTokenExpired = claims.getExpiration().before(new Date()); // true : 토큰이 만료됨
+            boolean isTokenTypeMatch = tokenType.name().equals(claims.get(JwtTokenProvider.TOKEN_TYPE_KEY));
+            return !isTokenExpired && isTokenTypeMatch;
+
+        } catch (JwtException | IllegalArgumentException exception) {
+            return false;
+        }
+    }
+}

--- a/module-api/src/main/java/com/study/api/jwt/JwtTokenProvider.java
+++ b/module-api/src/main/java/com/study/api/jwt/JwtTokenProvider.java
@@ -1,0 +1,75 @@
+package com.study.api.jwt;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.stereotype.Component;
+
+import java.util.Collection;
+import java.util.Date;
+import java.util.stream.Collectors;
+
+/**
+ * JWT 토큰을 생성하는 클래스입니다.
+ */
+@RequiredArgsConstructor
+@Component
+public class JwtTokenProvider {
+
+    private final JwtProperties jwtProperties;
+    public static final String AUTHORITIES_KEY = "ROLE";
+    public static final String TOKEN_TYPE_KEY = "type";
+    public static final String AUTHORITIES_DELIMITER = "<?>";
+
+    /**
+     * 권한 목록을 하나의 문자열로 변환합니다.
+     *
+     * @param grantedAuthorities Spring Security에서 권한을 나타내는 GrantedAuthority 객체들의 컬렉션
+     * @return 권한 목록을 문자열로 변환한 값
+     */
+    private static String toString(final Collection<? extends GrantedAuthority> grantedAuthorities) {
+        return grantedAuthorities.stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining(AUTHORITIES_DELIMITER));
+    }
+
+    /**
+     * 사용자 인증 정보를 바탕으로 액세스 토큰을 생성합니다.
+     *
+     * @param authentication 사용자 인증 정보
+     * @return 생성된 액세스 토큰
+     */
+    public String createAccessToken(Authentication authentication) {
+        Date now = new Date();
+        Date expiredAt = new Date(now.getTime() + jwtProperties.getAccessTokenValidTime() * 1000); // 유효 시간을 밀리초로 변환
+
+        return Jwts.builder()
+                .setHeaderParam("typ", "JWT")
+                .claim(TOKEN_TYPE_KEY, TokenType.ACCESS)
+                .claim(AUTHORITIES_KEY, toString(authentication.getAuthorities()))
+                .setSubject(authentication.getName())
+                .setIssuer(jwtProperties.getIssuer())
+                .setExpiration(expiredAt)
+                .signWith(SignatureAlgorithm.HS256, jwtProperties.getSecretKey())
+                .compact();
+    }
+
+    /**
+     * 리프레시 토큰을 생성합니다.
+     *
+     * @return 생성된 리프레시 토큰
+     */
+    public String createRefreshToken() {
+        Date now = new Date();
+        Date expiredAt = new Date(now.getTime() + jwtProperties.getRefreshTokenValidTime() * 1000);  // 유효 시간을 밀리초로 변환
+
+        return Jwts.builder()
+                .setHeaderParam("typ", "JWT")
+                .claim(TOKEN_TYPE_KEY, TokenType.REFRESH)
+                .signWith(SignatureAlgorithm.HS256, jwtProperties.getSecretKey())
+                .setExpiration(expiredAt)
+                .compact();
+    }
+}

--- a/module-api/src/main/java/com/study/api/jwt/TokenType.java
+++ b/module-api/src/main/java/com/study/api/jwt/TokenType.java
@@ -1,0 +1,8 @@
+package com.study.api.jwt;
+
+/**
+ * JWT 토큰의 타입을 나타내는 열거형입니다.
+ */
+public enum TokenType {
+    ACCESS, REFRESH
+}

--- a/module-api/src/main/java/com/study/api/jwt/filter/JwtTokenFilter.java
+++ b/module-api/src/main/java/com/study/api/jwt/filter/JwtTokenFilter.java
@@ -1,0 +1,173 @@
+package com.study.api.jwt.filter;
+
+import com.study.api.jwt.JwtProperties;
+import com.study.api.jwt.JwtTokenParser;
+import com.study.api.jwt.JwtTokenProvider;
+import com.study.api.jwt.TokenType;
+import com.study.api.permission.service.PermissionService;
+import com.study.common.exception.user.NotFoundUserException;
+import com.study.common.utill.CookieUtil;
+import com.study.domain.blog.entity.Blog;
+import com.study.domain.blogUser.entity.BlogUser;
+import com.study.domain.mapper.blog.BlogQueryMapper;
+import com.study.domain.mapper.bloguser.BlogUserQueryMapper;
+import com.study.domain.permission.entity.UserRole;
+import com.study.domain.redis.CookieProperties;
+import com.study.domain.redis.refreshToken.entity.RefreshToken;
+import com.study.domain.redis.refreshToken.repository.RefreshTokenQuery;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Optional;
+
+import static org.springframework.security.core.userdetails.User.builder;
+
+/**
+ * JWT 토큰 필터를 구현한 클래스입니다.
+ */
+@Component
+@RequiredArgsConstructor
+public class JwtTokenFilter extends OncePerRequestFilter {
+
+    private final JwtTokenParser jwtTokenParser;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final BlogUserQueryMapper blogUserQueryMapper;
+    private final BlogQueryMapper blogQueryMapper;
+    private final RefreshTokenQuery refreshTokenQuery;
+    private final CookieProperties cookieProperties;
+    private final JwtProperties jwtProperties;
+    private final PermissionService permissionService;
+
+
+    /**
+     * 요청을 필터링하여 JWT 토큰을 검증하고, 사용자 인증을 처리합니다.
+     *
+     * @param request  HTTP 요청 객체
+     * @param response HTTP 응답 객체
+     * @param filterChain 필터 체인
+     * @throws ServletException 서블릿 예외
+     * @throws IOException 입출력 예외
+     */
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+        String accessToken = extractBearerToken(request);
+        Optional<Cookie> refreshTokenCookie = CookieUtil.getCookie(request, TokenType.REFRESH.name());
+        String refreshToken = refreshTokenCookie.map(Cookie::getValue).orElse("");
+
+        if (jwtTokenParser.validateAccessToken(accessToken)) {
+            Authentication authentication = jwtTokenParser.extractAuthentication(accessToken);
+            SecurityContextHolder.getContext().setAuthentication(authentication);  // 인증 정보를 추출하고, SecurityContextHolder에 설정합니다.
+
+        } else if (jwtTokenParser.validateRefreshToken(refreshToken)) {
+
+            String userId = findUserIdByRefreshToken(refreshToken);
+            Blog blog = findBlogByUserId(userId);
+
+            TokenPair tokenPair = reissueTokenByUserId(userId, blog);
+
+            Authentication authentication = jwtTokenParser.extractAuthentication(tokenPair.accessToken);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+
+            response.setHeader("Authorization", "Bearer " + tokenPair.accessToken());
+
+            CookieUtil.addCookie(
+                    response,
+                    TokenType.REFRESH.name(),
+                    tokenPair.refreshToken(),
+                    jwtProperties.getRefreshTokenValidTime(),
+                    cookieProperties.getDomain(),
+                    cookieProperties.getSameSite());
+        } else {
+            SecurityContextHolder.clearContext();
+            CookieUtil.deleteCookie(response, TokenType.REFRESH.name(), cookieProperties.getDomain());
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    /**
+     * Refresh Token을 통해 사용자 ID를 찾습니다.
+     *
+     * @param refreshToken Refresh Token 값
+     * @return 사용자 ID
+     */
+    private String findUserIdByRefreshToken(String refreshToken) {
+        return refreshTokenQuery.findByValue(refreshToken)
+                .map(RefreshToken::getUserId)
+                .orElseThrow(IllegalArgumentException::new);
+    }
+
+    /**
+     * 사용자 ID를 통해 토큰을 재발급합니다.
+     *
+     * @param userId 사용자 ID
+     * @param blog 사용자의 블로그 정보
+     * @return 재발급된 토큰 access, refresh token 한 쌍
+     */
+    private TokenPair reissueTokenByUserId(String userId, Blog blog) {
+        BlogUser user = blogUserQueryMapper.findBlogUserByUserId(userId).orElseThrow(() -> new NotFoundUserException(userId));
+        UserRole userRole = permissionService.determineUserRole(blog, user);
+
+        UserRole role = userRole;
+
+        UserDetails userDetails = builder()
+                .username(user.getUserId())
+                .password(user.getPassword())
+                .authorities(Collections.singleton(new SimpleGrantedAuthority(role.name())))
+                .build();
+        Authentication authentication = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+        String newRefreshToken = jwtTokenProvider.createRefreshToken();
+        String newAccessToken = jwtTokenProvider.createAccessToken(authentication);
+
+        return new TokenPair(newAccessToken, newRefreshToken);
+    }
+
+    /**
+     * 요청에서 Bearer 토큰을 추출합니다.
+     *
+     * @param request HTTP 요청 객체
+     * @return Bearer를 제거한 토큰 값
+     */
+    private String extractBearerToken(HttpServletRequest request) {
+        String BearerToken = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (StringUtils.hasText(BearerToken) && BearerToken.startsWith(jwtProperties.getTokenPrefix())) {
+            return BearerToken.substring(jwtProperties.getTokenPrefix().length());
+        }
+        return null;
+    }
+
+    /**
+     * 사용자 ID를 통해 블로그를 찾습니다.
+     *
+     * @param userId 사용자 ID
+     * @return 사용자의 블로그 정보
+     */
+    private Blog findBlogByUserId(String userId) {
+        BlogUser user = blogUserQueryMapper.findBlogUserByUserId(userId).orElseThrow(() -> new NotFoundUserException(userId));
+        return blogQueryMapper.findBlogByUserId(user.getUserId());
+    }
+
+    /**
+     * 토큰 쌍을 나타내는 레코드 클래스입니다.
+     *
+     * @param accessToken Access Token 값
+     * @param refreshToken Refresh Token 값
+     */
+    private record TokenPair(String accessToken, String refreshToken) {}
+}

--- a/module-api/src/main/java/com/study/api/jwt/handler/JwtAccessDeniedHandler.java
+++ b/module-api/src/main/java/com/study/api/jwt/handler/JwtAccessDeniedHandler.java
@@ -1,0 +1,46 @@
+package com.study.api.jwt.handler;
+
+import com.study.common.exception.JwtErrorResponse;
+import com.study.common.utill.JsonUtils;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+/**
+ * 인증이 완료되었으나 해당 엔드포인트에 접근할 권한이 없는 경우 핸들러 클래스입니다.
+ */
+@Component
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+    /**
+     * 접근이 거부되었을 때 호출되는 메서드입니다.
+     *
+     * @param request  HTTP 요청 객체
+     * @param response HTTP 응답 객체
+     * @param accessDeniedException 접근 거부 예외
+     * @throws IOException 입출력 예외
+     * @throws ServletException 서블릿 예외
+     */
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        response.setStatus(HttpStatus.FORBIDDEN.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+
+        JwtErrorResponse responseBody = JwtErrorResponse.of(
+                HttpStatus.FORBIDDEN.value(),
+                HttpStatus.FORBIDDEN.getReasonPhrase(),
+                "권한이 없습니다.",
+                    request.getRequestURI());
+
+        response.getWriter().write(JsonUtils.convertObjectToJson(responseBody));
+
+    }
+}

--- a/module-api/src/main/java/com/study/api/jwt/handler/JwtAuthenticationEntryPointHandler.java
+++ b/module-api/src/main/java/com/study/api/jwt/handler/JwtAuthenticationEntryPointHandler.java
@@ -1,0 +1,51 @@
+package com.study.api.jwt.handler;
+
+import com.study.common.exception.JwtErrorResponse;
+import com.study.common.utill.JsonUtils;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+
+/**
+ * 사용자가 인증되지 않았거나 유효한 인증 정보가 부족한 경우를 처리하는 핸들러 클래스입니다.
+ */
+@Component
+public class JwtAuthenticationEntryPointHandler implements AuthenticationEntryPoint {
+
+
+    /**
+     * 인증 과정에서 예외가 발생했을 때 호출되는 메서드입니다.
+     *
+     * @param request       HTTP 요청 객체
+     * @param response      HTTP 응답 객체
+     * @param authException 인증 예외
+     * @throws IOException      입출력 예외
+     * @throws ServletException 서블릿 예외
+     */
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+
+        JwtErrorResponse responseBody = JwtErrorResponse.of(
+                HttpStatus.UNAUTHORIZED.value(),
+                HttpStatus.UNAUTHORIZED.getReasonPhrase(),
+                "인증 과정에 문제가 발생했습니다.",
+                request.getRequestURI());
+
+        String errorResponse = JsonUtils.convertObjectToJson(responseBody);
+
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(errorResponse);
+    }
+}

--- a/module-api/src/main/resources/application-cookie.yml
+++ b/module-api/src/main/resources/application-cookie.yml
@@ -1,0 +1,4 @@
+custom:
+  cookie:
+    domain: localhost
+    sameSite: None

--- a/module-api/src/main/resources/application-jwt.yml
+++ b/module-api/src/main/resources/application-jwt.yml
@@ -1,0 +1,8 @@
+jwt:
+  header: Authorization
+  secret: ${JWT_SECRET}
+  token-start-with: Bearer
+  token-validity-in-seconds: 604800  # 7일
+  refresh-token-validity-in-seconds: 2592000  # 30일
+  jwt-issuer: study-project
+  clock-skew-in-seconds: 30

--- a/module-api/src/main/resources/application.yml
+++ b/module-api/src/main/resources/application.yml
@@ -5,7 +5,9 @@ spring:
     include:
       - mail
       - aws
-
+      - jwt
+      - redis
+      - cookie
 
   datasource:
     url: jdbc:mysql://localhost:3306/study_project

--- a/module-common/src/main/java/com/study/common/exception/JwtErrorResponse.java
+++ b/module-common/src/main/java/com/study/common/exception/JwtErrorResponse.java
@@ -1,0 +1,62 @@
+package com.study.common.exception;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * JWT 관련 작업 중 발생한 오류 응답을 나타내는 클래스입니다.
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class JwtErrorResponse {
+
+    /** 오류가 발생한 타임스탬프입니다. */
+    private String timestamp;
+
+    /** 오류와 연관된 HTTP 상태 코드입니다. */
+    private int status;
+
+    /** 상태 코드에 따른 HTTP 오류 메시지입니다. */
+    private String error;
+
+    /** 오류에 대한 상세 메시지입니다. */
+    private String message;
+
+    /** 오류가 발생한 요청 경로입니다. */
+    private String path;
+
+    /**
+     * 주어진 세부 정보로 새로운 JwtErrorResponse 객체를 생성합니다.
+     *
+     * @param timestamp 오류 발생 시간대
+     * @param status HTTP 상태 코드
+     * @param error 상태 코드에 따른 HTTP 오류 메시지
+     * @param message 오류에 대한 상세 메시지
+     * @param path 오류가 발생한 요청 경로
+     */
+    private JwtErrorResponse(String timestamp, int status, String error, String message, String path) {
+        this.timestamp = timestamp;
+        this.status = status;
+        this.error = error;
+        this.message = message;
+        this.path = path;
+    }
+
+    /**
+     * 현재 시간을 기준으로 초기화된 JwtErrorResponse 객체를 생성합니다.
+     *
+     * @param status HTTP 상태 코드
+     * @param error 상태 코드에 따른 HTTP 오류 메시지
+     * @param message 오류에 대한 상세 메시지
+     * @param path 오류가 발생한 요청 경로
+     * @return 새로 생성된 JwtErrorResponse 객체
+     */
+    public static JwtErrorResponse of(int status, String error, String message, String path) {
+        String timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+        return new JwtErrorResponse(timestamp, status, error, message, path);
+    }
+}

--- a/module-common/src/main/java/com/study/common/utill/CookieUtil.java
+++ b/module-common/src/main/java/com/study/common/utill/CookieUtil.java
@@ -1,0 +1,120 @@
+package com.study.common.utill;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.experimental.UtilityClass;
+import org.springframework.http.ResponseCookie;
+
+import java.io.*;
+import java.util.Base64;
+import java.util.Optional;
+
+/**
+ * 유틸리티 클래스로, HTTP 쿠키 관련 기능을 제공합니다.
+ */
+@UtilityClass
+public final class CookieUtil {
+
+    /**
+     * HttpServletRequest에서 지정된 이름의 쿠키를 찾아서 Optional로 반환합니다.
+     *
+     * @param request HTTP 요청 객체
+     * @param name 쿠키 이름
+     * @return Optional<Cookie>
+     */
+    public Optional<Cookie> getCookie(HttpServletRequest request, String name) {
+        Cookie[] cookies = request.getCookies();
+
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if (name.equals(cookie.getName())) {
+                    return Optional.of(cookie);
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * HttpServletResponse에 쿠키를 추가합니다.
+     *
+     * @param response HTTP 응답 객체
+     * @param name 쿠키 이름
+     * @param value 쿠키 값
+     * @param maxAge 쿠키의 유효 시간 (초)
+     * @param domain 쿠키의 도메인
+     * @param sameSite SameSite 설정 ("Strict", "Lax", "None" 중 하나)
+     */
+    public void addCookie(HttpServletResponse response, String name, String value, long maxAge, String domain, String sameSite) {
+        ResponseCookie cookie = ResponseCookie.from(name, value)
+                .maxAge(maxAge)
+                .path("/")
+                .domain(domain)
+                .httpOnly(true)
+                .secure(true)
+                .sameSite(sameSite)
+                .build();
+
+        response.addHeader("Set-Cookie", cookie.toString());
+    }
+
+    /**
+     * HttpServletRequest와 HttpServletResponse에서 지정된 이름의 쿠키를 삭제합니다.
+     *
+     * @param response HTTP 응답 객체
+     * @param name 쿠키 이름
+     * @param domain 쿠키의 도메인
+     */
+    public void deleteCookie(HttpServletResponse response, String name, String domain) {
+        ResponseCookie deleteCookie = ResponseCookie.from(name, "")
+                .maxAge(0)
+                .path("/")
+                .domain(domain)
+                .httpOnly(true)
+                .secure(true)
+                .build();
+        response.addHeader("Set-Cookie", deleteCookie.toString());
+    }
+
+    /**
+     * 쿠키 값을 역직렬화하여 객체로 변환합니다.
+     *
+     * @param cookie 쿠키 객체
+     * @param clazz 변환할 클래스 타입
+     * @param <T> 변환할 객체의 타입
+     * @return 변환된 객체
+     */
+    public <T> T deserialize(Cookie cookie, Class<T> clazz) {
+        try {
+            byte[] decodedBytes = Base64.getUrlDecoder().decode(cookie.getValue());
+
+            try (ObjectInputStream inputStream = new ObjectInputStream(new ByteArrayInputStream(decodedBytes))) {
+                return clazz.cast(inputStream.readObject());
+            }
+        } catch (IOException | ClassNotFoundException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    /**
+     * 객체를 직렬화하여 쿠키 값으로 변환합니다.
+     *
+     * @param object 직렬화할 객체
+     * @return 직렬화된 쿠키 값
+     */
+    public String serialize(Object object) {
+        try {
+            ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+            try (ObjectOutputStream objectOutputStream = new ObjectOutputStream(byteArrayOutputStream)) {
+                objectOutputStream.writeObject(object);
+            }
+            byte[] serializedBytes = byteArrayOutputStream.toByteArray();
+            return Base64.getUrlEncoder().encodeToString(serializedBytes);
+        } catch (IOException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+}

--- a/module-domain/build.gradle
+++ b/module-domain/build.gradle
@@ -28,6 +28,16 @@ dependencies {
 	//validation
 	implementation 'org.springframework.boot:spring-boot-starter-validation:3.3.0'
 
+
+	//security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+
+	//redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis:3.3.0'
+	testImplementation "org.springframework.boot:spring-boot-starter-data-redis"
+	implementation 'io.lettuce:lettuce-core:6.2.3.RELEASE'
+	testImplementation "it.ozimov:embedded-redis:0.7.2"
+
 	// configuration-processor
 	implementation 'org.springframework.boot:spring-boot-configuration-processor:3.3.0'
 

--- a/module-domain/build.gradle
+++ b/module-domain/build.gradle
@@ -54,6 +54,8 @@ dependencies {
 	// h2
 	testImplementation 'com.h2database:h2:1.4.200'
 
+	// swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 
 	// mybatis
 	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.3'

--- a/module-domain/src/main/java/com/study/domain/ModuleDomainApplication.java
+++ b/module-domain/src/main/java/com/study/domain/ModuleDomainApplication.java
@@ -1,0 +1,17 @@
+package com.study.domain;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+
+@ConfigurationPropertiesScan
+@SpringBootApplication(scanBasePackages = {
+        "com.study.common", "com.study.domain"
+})
+public class ModuleDomainApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(ModuleDomainApplication.class, args);
+    }
+
+}

--- a/module-domain/src/main/java/com/study/domain/blogUser/dto/BlogUserDto.java
+++ b/module-domain/src/main/java/com/study/domain/blogUser/dto/BlogUserDto.java
@@ -135,4 +135,21 @@ public class BlogUserDto {
         }
     }
 
+    @Builder
+    public record BlogUserSignInRequestDto(
+            /**
+             * 사용자의 ID입니다.
+             */
+            @NotBlank
+            @Schema(description = "사용자의 ID입니다.", example = "user123")
+            String userId,
+
+            /**
+             * 사용자의 비밀번호입니다.
+             */
+            @NotBlank
+            @Schema(description = "사용자의 비밀번호입니다.", example = "Password1!")
+            String password
+    ) {
+    }
 }

--- a/module-domain/src/main/java/com/study/domain/redis/CookieProperties.java
+++ b/module-domain/src/main/java/com/study/domain/redis/CookieProperties.java
@@ -1,0 +1,29 @@
+package com.study.domain.redis;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+/**
+    설정 파일에서 쿠키 관련 프로퍼티를 로드하여 관리하는 클래스입니다.
+ */
+@Getter
+@Validated
+@ConfigurationProperties(prefix = "custom.cookie")
+@RequiredArgsConstructor
+public class CookieProperties {
+
+    /**
+     * 쿠키의 도메인을 나타내는 프로퍼티입니다.
+     */
+    @NotNull
+    private final String domain;
+
+    /**
+     * 쿠키의 SameSite 속성을 나타내는 프로퍼티입니다.
+     */
+    @NotNull
+    private final String sameSite;
+}

--- a/module-domain/src/main/java/com/study/domain/redis/config/RedisConfig.java
+++ b/module-domain/src/main/java/com/study/domain/redis/config/RedisConfig.java
@@ -1,0 +1,67 @@
+package com.study.domain.redis.config;
+
+import com.study.domain.post.dto.PostDto;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+
+/**
+ * Redis 관련 설정을 구성하는 클래스입니다.
+ */
+@Configuration
+public class RedisConfig {
+
+
+    @Value("${redis.host}")
+    private String redisHost;
+
+    @Value("${redis.port}")
+    private int redisPort;
+
+    /**
+     * RedisConnectionFactory를 생성합니다.
+     *
+     * @return RedisConnectionFactory
+     */
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisHost, redisPort);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> objectRedisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+
+        // For keys and refresh tokens (String)
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+
+        // For values (Object)
+        redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer(PostDto.PostResponse.class));
+        redisTemplate.setHashValueSerializer(new Jackson2JsonRedisSerializer(PostDto.PostResponse.class));
+
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        return redisTemplate;
+    }
+
+
+    /**
+     * RedisTemplate을 생성합니다.
+     *
+     * @return RedisTemplate
+     */
+    @Bean
+    public RedisTemplate<String, String> redisTemplate() {
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        return redisTemplate;
+    }
+}

--- a/module-domain/src/main/java/com/study/domain/redis/refreshToken/entity/RefreshToken.java
+++ b/module-domain/src/main/java/com/study/domain/redis/refreshToken/entity/RefreshToken.java
@@ -1,0 +1,43 @@
+package com.study.domain.redis.refreshToken.entity;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+
+/**
+ *  Redis에 저장되는 리프레시 토큰 엔티티를 정의합니다.
+ */
+@Getter
+@RedisHash(value = "refreshToken", timeToLive = 604800) // 이 클래스가 Redis 해시(hash) 구조로 저장될 것임을 나타낸다. value 속성은 Redis 해시의 이름을 지정한다.
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RefreshToken {
+
+    /**
+     * 사용자 ID로, Redis 해시의 키로 사용됩니다. "refreshToken:{userId}"와 같은 키가 생성됩니다.
+     */
+    @Id
+    private String userId;
+
+
+    /**
+     * 리프레시 토큰의 값으로, 인덱스가 생성됩니다.
+     */
+    private String value;
+
+    /**
+     * RefreshToken 생성자.
+     *
+     * @param userId 사용자 ID
+     * @param value 리프레시 토큰의 값
+     */
+    @Builder
+    public RefreshToken(String userId, String value) {
+        this.userId = userId;
+        this.value = value;
+    }
+
+}

--- a/module-domain/src/main/java/com/study/domain/redis/refreshToken/repository/RefreshTokenCommand.java
+++ b/module-domain/src/main/java/com/study/domain/redis/refreshToken/repository/RefreshTokenCommand.java
@@ -1,0 +1,33 @@
+package com.study.domain.redis.refreshToken.repository;
+
+import com.study.domain.redis.refreshToken.entity.RefreshToken;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+
+/**
+ * RefreshTokenCommand는 리프레시 토큰을 관리하기 위한 서비스 클래스로
+ * 이 클래스는 리프레시 토큰을 저장하고 삭제하는 기능을 제공합니다.
+ */
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenCommand {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    /**
+     * 리프레시 토큰을 저장합니다. 저장하기 전에 리프레시 토큰의 TTL(Time-To-Live)을 업데이트합니다.
+     *
+     * @param refreshToken 저장할 리프레시 토큰
+     * @return 저장된 리프레시 토큰
+     */
+    public RefreshToken save(RefreshToken refreshToken) {
+        return refreshTokenRepository.save(refreshToken);
+    }
+
+
+    public void deleteById(String userId) {
+        refreshTokenRepository.deleteById(userId);
+    }
+
+}

--- a/module-domain/src/main/java/com/study/domain/redis/refreshToken/repository/RefreshTokenQuery.java
+++ b/module-domain/src/main/java/com/study/domain/redis/refreshToken/repository/RefreshTokenQuery.java
@@ -1,0 +1,35 @@
+package com.study.domain.redis.refreshToken.repository;
+
+import com.study.domain.redis.refreshToken.entity.RefreshToken;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenQuery{
+
+    private final RefreshTokenRepository refreshTokenRepository;
+
+
+    /**
+     * 주어진 값으로 리프레시 토큰을 조회합니다.
+     *
+     * @param value 리프레시 토큰의 값
+     * @return 값이 일치하는 리프레시 토큰을 포함한 Optional 객체
+     */
+    public Optional<RefreshToken> findByValue(String value) {
+        return refreshTokenRepository.findByValue(value);
+    }
+
+    /**
+     * 주어진 값이 존재하는지 확인합니다.
+     *
+     * @param value 리프레시 토큰의 값
+     * @return 값이 존재하면 true, 그렇지 않으면 false
+     */
+    public boolean existsByValue(String value) {
+        return refreshTokenRepository.existsByValue(value);
+    }
+}

--- a/module-domain/src/main/java/com/study/domain/redis/refreshToken/repository/RefreshTokenRepository.java
+++ b/module-domain/src/main/java/com/study/domain/redis/refreshToken/repository/RefreshTokenRepository.java
@@ -1,0 +1,32 @@
+package com.study.domain.redis.refreshToken.repository;
+
+import com.study.domain.redis.refreshToken.entity.RefreshToken;
+import org.springframework.data.repository.CrudRepository;
+
+import java.util.Optional;
+
+
+/**
+ * RefreshTokenRepository는 리프레시 토큰을 관리하기 위한 저장소 인터페이스로
+ * 리프레시 토큰을 값으로 조회하고 존재 여부를 확인하는 메서드를 제공합니다.
+ *
+ */
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, String> {
+
+    /**
+     * 주어진 값으로 리프레시 토큰을 조회합니다.
+     *
+     * @param value 리프레시 토큰의 값
+     * @return 값이 일치하는 리프레시 토큰을 포함한 Optional 객체
+     */
+    Optional<RefreshToken> findByValue(String value);
+
+
+    /**
+     * 주어진 값이 존재하는지 확인합니다.
+     *
+     * @param value 리프레시 토큰의 값
+     * @return 값이 존재하면 true, 그렇지 않으면 false
+     */
+    boolean existsByValue(String value);
+}

--- a/module-domain/src/main/resources/application-redis.yml
+++ b/module-domain/src/main/resources/application-redis.yml
@@ -1,0 +1,7 @@
+redis:
+  host: localhost
+  port: 6379
+  region:
+    static: ap-northeast-2
+  ttl:
+    refreshToken: 600

--- a/module-domain/src/main/resources/application.yml
+++ b/module-domain/src/main/resources/application.yml
@@ -4,4 +4,4 @@ spring:
   profiles:
     include:
       - rdb
-
+      - redis

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,5 @@
+rootProject.name = 'mb-muti'
+
+include 'module-api'
+include 'module-domain'
+include 'module-common'


### PR DESCRIPTION
### 연관 Issue 정보
> - #7

### 작업 내용 요약
- [x] 로그인, JWT 관련 예외처리 생성
- [x] 로그인과 관련된 mybatis 파일 생성
- [x] 로그인 시 JWT(Refresh, Access) 발급
- [x] Refresh Token을 저장하는 Redis 구현
- [x] 스프링 시큐리티 설정
- [x] 로그인에 관한 예외처리

### 작업 상세 내용

- JWT 설정을 위한 yml 파일을 생성한다. 엑세스토큰은 7일, 리프레쉬토큰의 유효기간은 30일이다.
![image](https://github.com/user-attachments/assets/8f228a2f-0334-49b9-a49e-94028b8620c6)
![image](https://github.com/user-attachments/assets/63f115f4-6561-4add-9f03-e6ef5d57fcaf)


- redis 사용을 위한 Config 파일을 생성한다.
![image](https://github.com/user-attachments/assets/60ee0c91-7907-4a63-ad37-1dbd473f8d56)
![image](https://github.com/user-attachments/assets/cb42495d-990d-44be-9864-292334cc53d6)

- 먼저 로그인 비즈니스 로직에서 사용되는 것 들이다. 아래에서 같이 설명한다.

![](https://velog.velcdn.com/images/chas369/post/75a685d0-fa5f-4017-9340-bd5b3256ca12/image.png)


- 위에서부터 차례대로 설명한다.

![](https://velog.velcdn.com/images/chas369/post/bdcddb5b-684b-445a-840b-7e6c16ae30c8/image.png)


- 먼저 authenticateUser 메서드이다. 반환되는 Authentication 객체는 Spring Security의 인증 과정을 통해 생성되며 아이디와 비밀번호를 입력해서 로그인에 성공한 사용자의 인증정보를 담고 있다. getName, getAuthorities, getPrincipal 등의 메서드로 사용자정보를 가져올 수 있다.

![](https://velog.velcdn.com/images/chas369/post/ca1b4535-4c5e-427e-8cd7-3cf44f7d4f68/image.png)


- 엑세스토큰과 리프레쉬토큰을 생성하는 메서드이다. 엑세스토큰을 생성할 때는 인증된 사용자정보가 사용된다. 리프레시 토큰을 생성할 때는 Authentication 객체가 필요하지 않은 이유는 리프레쉬토큰은 단순히 액세스 토큰을 갱신하는 데에만 사용되기 때문이다.

![](https://velog.velcdn.com/images/chas369/post/9f046b9b-59b8-4248-9bc9-659d2c6fd298/image.png)


- 토큰을 생성하는 코드가 있는 JwtTokenProvider로 가보자. 여기서 toString 메서드는 사용자가 가진 권한을 나타내는 GrantedAuthority 객체들의 컬렉션을 문자열로 변환하는 메서드이다.
- getAuthority() 메서드를 통해 해당 권한들의 문자열을 가져오고 Collectors.joining(AUTHORITIES_DELIMITER)를 사용하여 각 권한 문자열을 구분자(AUTHORITIES_DELIMITER)로 연결하여 하나의 문자열로 만든다.
- 사용자 정보는 토큰의 페이로드에 들어가는데 간결하게 표현하고 좀 더 쉽게 다루기위해 하나의 문자열로 바꾼다

![](https://velog.velcdn.com/images/chas369/post/b3d98092-29c0-44a4-9144-8a3c447b7a9b/image.png) 

- JWT 페이로드의 예시이다. **페이로드는 Base64 URL-safe 인코딩으로 인코딩되어 있으며, 디코딩하면 JSON 형태의 데이터를 확인할 수 있다.**

```
디코딩 전
eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyMSIsInJvbGVzIjoiUk9MRV9VU0VSIiwiZXhwIjoxNjI2MTQ5OTk5fQ.rfr3r5kU9sHuyu9cyEe5EBvGosRFF4s0PfPdS91QDSI

디코딩 후,

{
  "sub": "user1",
  "roles": "ROLE_USER",
  "exp": 1626149999
}

```


- 엑세스토큰과 리프레쉬토큰 생성 메서드이다. 토큰 설정정보가 있는 JwtProperties 클래스로 이동해보자.

![](https://velog.velcdn.com/images/chas369/post/ae98bcf8-bc75-4bde-8fdf-4516d7f36bdb/image.png)


- @Value로 설정된 값을 가져와서 세팅해준다.
1. secretKey: JWT를 서명하기 위한 비밀 키로 서명된 토큰을 검증할 때 사용된다. 인코딩된 페이로드를 디코딩할 때 사용된다. 

2. accessTokenValidTime: 발급된 액세스 토큰의 유효 시간으로 토큰은 발행 시점에서 유효 시간 만큼만 유효하며, 이 시간이 지나면 만료된다.

3. refreshTokenValidTime: 발급된 액세스 토큰의 유효 시간으로 토큰은 발행 시점에서 유효 시간 만큼만 유효하며, 이 시간이 지나면 만료된다. 리프레시 토큰은 주로 액세스 토큰이 만료되었을 때 새로운 액세스 토큰을 발급받기 위해 사용된다.

4. issuer: JWT의 발급자(issuer) 정보이다. 발급된 토큰이 어디에서 발급되었는지를 나타내는 식별자이다.

5. tokenPrefix: 클라이언트가 JWT를 식별할 수 있도록 토큰 앞에 붙이는 접두어입니다. 예를 들어, "Bearer "와 같이 인증 헤더에 토큰을 식별하기 위해 사용된다.

6. header: HTTP 요청에서 JWT를 식별할 헤더의 이름입니다. 보통 "Authorization" 헤더에 JWT를 실어 보낸다.

![](https://velog.velcdn.com/images/chas369/post/c0e976fc-938d-450b-ab85-abfd2b3d7f59/image.png)

- 생성된 리프레쉬토큰을 저장하는 로직이다. refreshTokenCommand와 RefreshToken 클래스로 가보자.

![](https://velog.velcdn.com/images/chas369/post/597857a7-5b5f-4815-b198-fe8910b15acb/image.png)


![](https://velog.velcdn.com/images/chas369/post/1b53c56c-6a34-48d7-aee1-199f8eb5cd41/image.png)



- 그럼 이제 RefreshToken 클래스로 가보자. RefreshToken를 redis에 저장하기 위한 코드이다.

![](https://velog.velcdn.com/images/chas369/post/62b48276-fcc1-44f5-a0ad-bd72a598f5cb/image.png)


- `@RedisHash`: 이 클래스가 Redis의 해시(hash) 데이터 구조로 저장될 것임을 나타내는 애노테이션입니다. 여기서 value는 Redis에서 해당 클래스의 객체가 저장될 해시의 이름을 의미한다. 뒤에 `TimeToLive`는 레디스에 저장된 값의 저장기간을 의미한다.

- `@Id` :  redis의 key로 사용하겠다는 의미이다. 여기서는 redis에 값이 저장될 때 userId가 key, 저장되는 값이 value가 되는 것이다.

![](https://velog.velcdn.com/images/chas369/post/cc85cff5-d4a1-47e2-960b-2fe10772c724/image.png)


- 결과를 보면 "refreshToken:{userId}" 형식으로 key가 형성되고 value로 refreshToken의 값이 들어갔다.
- 앞에 있는 refreshToken은 아까 말한대로 @RedisHash로 생성된 해시의 이름이다.

- timeToLive와 jwt토큰의 expiration의 차이점
  - redis에서 해당 객체의 데이터가 유효한 시간을 지정하고, TTL이 지나면 Redis에서 자동으로 삭제된다
  - JWT 토큰의 만료 시간을 설정하여, 특정 시점 이후에 토큰이 더 이상 유효하지 않음을 의미한다.
  - Redis에서 객체의 TTL을 따로 설정하지 않으며, 객체는 수동으로 삭제하거나 다른 TTL 설정 방법을 사용해야한다.

![](https://velog.velcdn.com/images/chas369/post/6dc1febe-15f3-4c60-a96e-543a44c5e2b3/image.png)

![](https://velog.velcdn.com/images/chas369/post/c666542e-e0e8-4791-883e-65a582caf32f/image.png)

- addTokenCookie 메서드를 통해 특정 타입의 토큰을 HTTP 응답에 쿠키로 추가하는 기능을 구현한다.
  - HttpServletResponse response : HTTP 응답 객체에 쿠키를 담기 위함
  - TokenType tokenType : 토큰의 타입
  - String tokenValue : 토큰 값
  - long tokenLifeTime : 토큰의 유효기간
  
- 좀 더 자세히 보기위해 CookieUtil로 이동한다. 쿠키에서 제공하는 메서드로 쿠키 옵션을 설정하고 쿠키를 생성하는 메서드이다.

1. HttpServletResponse response: HTTP 응답 객체
2. String name: 쿠키의 이름
3. String value: 쿠키의 값
4. long maxAge: 쿠키의 생명 주기
5. String domain: 도메인 설정
6. String sameSite: SameSite 설정

![](https://velog.velcdn.com/images/chas369/post/103a4ff4-77fc-4aaf-b96f-d88b148fa502/image.png)

- `ResponseCookie.from(name, value)` : 주어진 이름(name)과 값(value)으로 ResponseCookie 객체를 생성
- `maxAge()` : 쿠키의 생명 주기 (TTL)를 설정
- `path("/")` : 쿠키의 경로를 설정합니다. 여기서는 모든 경로에서 쿠키가 유효하도록 /로 설정
- `domain(domain)` : 쿠키가 유효한 도메인을 설정
- `httpOnly(true)` : 쿠키를 HTTP 전용으로 설정하여, 클라이언트 측 스크립트에서 접근할 수 없도록 함
- `secure(true)` : 이 속성이 true로 설정되면, 쿠키는 HTTPS 연결에서만 전송
- `sameSite()` : 쿠키의 SameSite 속성을 설정하여, CSRF 공격을 방지
- `response.addHeader("Set-Cookie", cookie.toString())` : 빌드한 ResponseCookie 객체를 문자열로 변환하여 HTTP 응답 헤더에 추가


마지막으로 아래 코드는 생성된 엑세스 토큰을 HTTP 응답 헤더에 세팅하는 코드이다. "Authorization"는 설정하려는 헤더의 이름으로 인증 토큰을 담는 데 사용된다.
`response.setHeader("Authorization", accessTokenValue);`

## 1. JwtErrorResponse 생성
- jwt 와 관련된 응답을 위해 JwtErrorResponse 클래스를 따로 생성했다.
```
/**
 * JWT 관련 작업 중 발생한 오류 응답을 나타내는 클래스입니다.
 */
@Getter
@NoArgsConstructor(access = AccessLevel.PROTECTED)
public class JwtErrorResponse {

    /** 오류가 발생한 타임스탬프입니다. */
    private String timestamp;

    /** 오류와 연관된 HTTP 상태 코드입니다. */
    private int status;

    /** 상태 코드에 따른 HTTP 오류 메시지입니다. */
    private String error;

    /** 오류에 대한 상세 메시지입니다. */
    private String message;

    /** 오류가 발생한 요청 경로입니다. */
    private String path;

    /**
     * 주어진 세부 정보로 새로운 JwtErrorResponse 객체를 생성합니다.
     *
     * @param timestamp 오류 발생 시간대
     * @param status HTTP 상태 코드
     * @param error 상태 코드에 따른 HTTP 오류 메시지
     * @param message 오류에 대한 상세 메시지
     * @param path 오류가 발생한 요청 경로
     */
    private JwtErrorResponse(String timestamp, int status, String error, String message, String path) {
        this.timestamp = timestamp;
        this.status = status;
        this.error = error;
        this.message = message;
        this.path = path;
    }

    /**
     * 현재 시간을 기준으로 초기화된 JwtErrorResponse 객체를 생성합니다.
     *
     * @param status HTTP 상태 코드
     * @param error 상태 코드에 따른 HTTP 오류 메시지
     * @param message 오류에 대한 상세 메시지
     * @param path 오류가 발생한 요청 경로
     * @return 새로 생성된 JwtErrorResponse 객체
     */
    public static JwtErrorResponse of(int status, String error, String message, String path) {
        String timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
        return new JwtErrorResponse(timestamp, status, error, message, path);
    }
}
```

## 1. JwtAccessDeniedHandler 

```
/**
 * JWT 인증이 실패할 때 접근 거부를 처리하는 핸들러 클래스입니다.
 */
@Component
public class JwtAccessDeniedHandler implements AccessDeniedHandler {

    /**
     * 접근이 거부되었을 때 호출되는 메서드입니다.
     *
     * 이 메서드는 클라이언트가 권한이 없는 리소스에 접근하려고 할 때 호출됩니다.
     *  HTTP 응답 코드 403(Forbidden)와 함께 예외 정보를 포함한 JSON 응답을 전송합니다.
     *
     * @param request  HTTP 요청 객체
     * @param response HTTP 응답 객체
     * @param accessDeniedException 접근 거부 예외
     * @throws IOException 입출력 예외
     * @throws ServletException 서블릿 예외
     */
    @Override
    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
        response.setStatus(HttpStatus.FORBIDDEN.value());
        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
        response.setCharacterEncoding("UTF-8");

        JwtErrorResponse responseBody = JwtErrorResponse.of(
                HttpStatus.FORBIDDEN.value(),
                HttpStatus.FORBIDDEN.getReasonPhrase(),
                "권한이 없습니다.",
                    request.getRequestURI());

        response.getWriter().write(JsonUtils.convertObjectToJson(responseBody));

    }
}


```

![](https://velog.velcdn.com/images/chas369/post/8c1a6bcf-2cc5-4fb4-a6c5-a405a95a4755/image.png)


- JWT 인증이 실패할 때 처리하는 핸들러 클래스인 JwtAccessDeniedHandler를 구현했다.
- HTTP 요청 객체(request), HTTP 응답 객체(response), 접근 거부 예외(accessDeniedException) 파라미터를 받는다
- HTTP 응답 상태를 403 Forbidden으로 설정한다
- 응답의 컨텐츠 타입을 JSON으로 설정한다
- UTF-8 인코딩으로 문자열을 설정한다.
---
- responseBody는 JwtAccessDeniedHandler 클래스의 handle 메서드에서 접근 거부 상황에 대한 정보를 클라이언트에게 JSON 형식으로 전달하기 위해 사용된다.

  - HttpStatus.FORBIDDEN.value() :  403 (Forbidden)을 설정하여 클라이언트가 권한이 없음을 명확하게 알림

  - HttpStatus.FORBIDDEN.getReasonPhrase() : 상태 코드에 해당하는 기본 오류 메시지를 저장

  - request.getRequestURI() : 클라이언트가 어느 경로로 요청을 시도하다가 거부되었는지 알 수 있게 함

- response.getWriter().write(JsonUtils.convertObjectToJson(responseBody)); : 위에서 생성한 JSON 객체를 문자열로 변환하여 응답 본문에 기록한다.

![](https://velog.velcdn.com/images/chas369/post/2c974cf1-6536-4d54-bfb0-1372a6b6ee06/image.png)

- convertObjectToJson 메서드는 JsonUtils에 있다. @UtilityClass 어노테이션은 해당 클래스의 기본생성자를 private으로, 모든 필드와 메서드를 static으로 설정한다.
- ObjectMapper는  JSON을 Java 객체로 변환하거나 Java 객체를 JSON으로 변환할 때 사용하는 Jackson 라이브러리이다. 여기서는 ObjectMapper의 writeValueAsString 메서드를 사용하여 객체를 JSON 문자열로 변환한다.

## 2. JwtAuthenticationEntryPointHandler
```
package com.study.api.jwt.handler;

import com.study.common.exception.JwtErrorResponse;
import com.study.common.utill.JsonUtils;
import jakarta.servlet.ServletException;
import jakarta.servlet.http.HttpServletRequest;
import jakarta.servlet.http.HttpServletResponse;
import org.springframework.http.HttpStatus;
import org.springframework.http.MediaType;
import org.springframework.security.core.AuthenticationException;
import org.springframework.security.web.AuthenticationEntryPoint;
import org.springframework.stereotype.Component;

import java.io.IOException;


/**
 * JWT 인증 과정에서 발생하는 예외를 처리하는 핸들러 클래스로 인증되지 않은 상태로 보호된 리소스에 접근하려고 할 때 호출됩니다.
 */
@Component
public class JwtAuthenticationEntryPointHandler implements AuthenticationEntryPoint {


    /**
     * 인증 과정에서 예외가 발생했을 때 호출되는 메서드입니다.
     *
     * 이 메서드는 클라이언트가 인증되지 않은 상태로 보호된 리소스에 접근하려고 할 때 호출됩니다.
     *  HTTP 응답 코드 401(Unauthorized)와 함께 예외 정보를 포함한 JSON 응답을 전송합니다.
     *
     * @param request       HTTP 요청 객체
     * @param response      HTTP 응답 객체
     * @param authException 인증 예외
     * @throws IOException      입출력 예외
     * @throws ServletException 서블릿 예외
     */
    @Override
    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
        response.setCharacterEncoding("UTF-8");

        JwtErrorResponse responseBody = JwtErrorResponse.of(
                HttpStatus.UNAUTHORIZED.value(),
                HttpStatus.UNAUTHORIZED.getReasonPhrase(),
                "인증 과정에 문제가 발생했습니다.",
                request.getRequestURI());

        String errorResponse = JsonUtils.convertObjectToJson(responseBody);
        
        response.getWriter().write(errorResponse);
    }
}

```

![](https://velog.velcdn.com/images/chas369/post/5118b2a2-5420-48da-a7a6-0360fbed4765/image.png)

