### PR TITLE
feat: #12 블로그마다 가지는 유저의 권한에 대해 설정한다.

### DIFF
--- a/module-api/src/main/java/com/study/api/config/SecurityConfig.java
+++ b/module-api/src/main/java/com/study/api/config/SecurityConfig.java
@@ -8,6 +8,9 @@ import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.access.PermissionEvaluator;
+import org.springframework.security.access.expression.method.DefaultMethodSecurityExpressionHandler;
+import org.springframework.security.access.expression.method.MethodSecurityExpressionHandler;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -32,6 +35,7 @@ public class SecurityConfig {
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
     private final JwtAuthenticationEntryPointHandler jwtAuthenticationEntryPoint;
     private final JwtTokenFilter jwtTokenFilter;
+    private final PermissionEvaluator permissionEvaluator;
 
     /**
      * 비밀번호를 암호화하기 위한 {@link PasswordEncoder} 빈을 생성합니다.
@@ -88,4 +92,10 @@ public class SecurityConfig {
         return http.build();
     }
 
+    @Bean
+    public MethodSecurityExpressionHandler methodSecurityExpressionHandler() {
+        DefaultMethodSecurityExpressionHandler handler = new DefaultMethodSecurityExpressionHandler();
+        handler.setPermissionEvaluator(permissionEvaluator);
+        return handler;
+    }
 }

--- a/module-api/src/main/java/com/study/api/permission/service/CustomPermissionEvaluator.java
+++ b/module-api/src/main/java/com/study/api/permission/service/CustomPermissionEvaluator.java
@@ -1,0 +1,35 @@
+package com.study.api.permission.service;
+
+
+import com.study.domain.permission.entity.UserRole;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.PermissionEvaluator;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+import java.io.Serializable;
+
+@Component
+@RequiredArgsConstructor
+public class CustomPermissionEvaluator implements PermissionEvaluator {
+
+    private final PermissionService permissionService;
+
+    @Override
+    public boolean hasPermission(Authentication authentication, Object targetDomainObject, Object permission) {
+        if (!(targetDomainObject instanceof Long) || !(permission instanceof UserRole)) {
+            return false;
+        }
+        String userId = authentication.getName();
+        Long blogId = (Long) targetDomainObject;
+        UserRole requiredUserRole = (UserRole) permission;
+
+        UserRole userRole = permissionService.getUserRoleForBlog(blogId, userId);
+        return userRole.equals(requiredUserRole);
+    }
+
+    @Override
+    public boolean hasPermission(Authentication authentication, Serializable targetId, String targetType, Object permission) {
+        return false;
+    }
+}

--- a/module-api/src/main/java/com/study/api/permission/service/PermissionService.java
+++ b/module-api/src/main/java/com/study/api/permission/service/PermissionService.java
@@ -1,0 +1,48 @@
+package com.study.api.permission.service;
+
+
+import com.study.common.exception.user.NotFoundUserException;
+import com.study.domain.blog.entity.Blog;
+
+import com.study.domain.blogUser.entity.BlogUser;
+
+import com.study.domain.mapper.blog.BlogQueryMapper;
+import com.study.domain.mapper.bloguser.BlogUserQueryMapper;
+import com.study.domain.permission.entity.UserRole;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PermissionService {
+
+    private final BlogQueryMapper blogQueryMapper;
+    private final BlogUserQueryMapper blogUserQueryMapper;
+
+
+    public UserRole getUserRoleForBlog(long blogId, String userId) {
+        Blog blog = blogQueryMapper.findBlogByBlogId(blogId);
+        BlogUser user = blogUserQueryMapper.findBlogUserByUserId(userId)
+                .orElseThrow(() -> new NotFoundUserException(userId));
+
+        return determineUserRole(blog, user);
+    }
+
+    /**
+     * 주어진 사용자와 블로그에 대한 권한을 결정합니다.
+     *
+     * @param blog 블로그
+     * @param user 사용자
+     * @return 권한
+     */
+    public UserRole determineUserRole(Blog blog, BlogUser user) {
+        if (blog.getUserId().equals(user.getUserId())) {
+            return UserRole.ROLE_ADMIN;
+        } else if (!blog.getUserId().equals(user.getUserId())) {
+            return UserRole.ROLE_MEMBER;
+        } else {
+            return UserRole.ROLE_GUEST;
+        }
+    }
+
+}

--- a/module-domain/src/main/java/com/study/domain/permission/entity/UserRole.java
+++ b/module-domain/src/main/java/com/study/domain/permission/entity/UserRole.java
@@ -1,0 +1,5 @@
+package com.study.domain.permission.entity;
+
+public enum UserRole {
+    ROLE_ADMIN, ROLE_MEMBER, ROLE_GUEST
+}


### PR DESCRIPTION
### 연관 Issue 정보
> - #12 

### 작업 내용 요약
- [x] 유저의 권한을 ADMIN, MEMBER, GUEST로 나눈다.
- [x] 유저의 블로그인지에 따라 권한을 유동적으로 부여한다.
- [x] 메서드마다 접근할 수 있는 권한을 다르게 설정한다.

### 작업 상세 내용
- 자신의 블로그인 경우 ADMIN, 타인의 블로그인 경우 MEMBER, 로그인 하지 않은 경우 GUEST로 설정한다. Enum클래스에 권한의 종류를 설정한다.
![image](https://github.com/user-attachments/assets/781faa6d-f8c6-444e-bbaa-6e00c3523a91)

- 블로그에 대해 사용자가 어떤 권한을 가지는지를 판단하는 서비스를 제공한다. 
블로그의 소유자와 사용자가 동일하면 ROLE_ADMIN 역할을 부여하고, 그렇지 않으면 ROLE_MEMBER 역할을 부여합니다. 로그인하지 않았으면 GUEST 권한을 부여한다.
![image](https://github.com/user-attachments/assets/cb3ac9b4-5034-4c6f-bab3-ef77f31270a4)

- UserDetailService에 getUserRoleForBlog 메서드가 추가된다. determineUserRole로 결정된 사용자의 권한을 현재 로그인 중인 사용자에게 설정한다.
![image](https://github.com/user-attachments/assets/85e54fb0-eca2-49cb-9b8f-2cda0be1c286)


- PermissionEvaluator : 이 클래스는 주로 Spring Security의 @PreAuthorize 및 @Secured 어노테이션과 함께 사용되며, 특정 도메인 객체와 권한객체를 기반으로 사용자 권한을 평가한다. 기본적으로 Authentication이 targetDomainObject에 대해 가지고 있는 권한수준을 의미한다. 
- Authentication authentication : 현재 인증된 사용자의 정보를 담고 있는 객체
- Object targetDomainObject : 검증할 특정 도메인 객체의 ID나, 객체 자체 (해당 도메인에 접근할 수 있는가)
일반적으로 Long 타입으로 도메인 객체의 식별자를 받는다.
예를 들어, 블로그 게시글의 ID를 받아서 해당 게시글이 현재 사용자에게 접근 가능한지 확인한다.
- Object permission : targetDomainObject에게 접근하기 위해 사용자에게 요구되는 권한 수준을 정의한다. @PreAuthorize에서 정한 role이 들어가게된다.
즉, determineUserRole으로 결정된 사용자의 권한과 @PreAuthorize에서 정한 role이 들어간 permission을 비교해서 true와 false를 반환하는 것이다.
![image](https://github.com/user-attachments/assets/c37529cd-8104-4566-b87f-970c90c3afbe)


- 메서드 수준의 보안 설정을 위해 커스텀한 Evaluator를 등록한다. 메서드에 접근할 권한이 있는지 평가한다. (SecurityConfig)
![image](https://github.com/user-attachments/assets/66be7fd8-47de-4c4f-8c2f-247e40f41438)


- jwt를 사용한 로그인과 api 작동과정을 설명하자면

1. 사용자가 아이디와 비밀번호 입력

2. 클라이언트가 전송한 인증 정보는 UsernamePasswordAuthenticationToken 객체로 생성

3. AuthenticationManager는 ProviderManager에게 인증을 위임

4. UserDetailsService 인터페이스를 구현한 클래스의 loadUserByUsername 메서드를 사용해서 사용자의 정보를 데이터베이스에서 가져옴. 여기선 아이디만 가져가서 사용자 정보를 가져오고 이걸 UserDetails 객체로 만들어서 반환

5. UserDetails 객체와 클라이언트가 제공한 아이디, 비밀번호를 비교하여 사용자를 인증, 여기서는 블로그의 아이디와 입력받은 아이디를 비교해서 권한까지 설정

6. 인증에 성공하면 AuthenticationProvider는 인증된 사용자를 나타내는 Authentication 객체를 생성

7. 이 정보는 Spring Security의 SecurityContextHolder에 설정

8. API 요청이 컨트롤러로 전달

9. @PreAuthorize 어노테이션으로 인해 내부적으로 CustomPermissionEvaluator를 호출하여 권한 검증을 수행
![image](https://github.com/user-attachments/assets/a75c1e58-679a-4b05-a7d1-96fbe71215c0)
