### PR TITLE
feat: #14 로그아웃과 회원탈퇴 기능을 구현한다.

### DIFF
--- a/module-api/src/main/java/com/study/api/blogUser/controller/BlogUserController.java
+++ b/module-api/src/main/java/com/study/api/blogUser/controller/BlogUserController.java
@@ -143,5 +143,48 @@ public class BlogUserController {
         return ResponseEntity.noContent().build();
     }
 
+    /**
+     * 로그아웃 요청을 처리합니다.
+     *
+     * @param response HTTP 응답 객체
+     * @param userId 현재 로그인 중인 사용자 ID
+     * @return HTTP 상태 코드 204 (No Content) 로그아웃 성공
+     */
+    @Operation(
+            summary = "로그아웃",
+            description = "현재 로그인 중인 사용자가 로그아웃을 수행합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "로그아웃 성공"),
+            @ApiResponse(responseCode = "500", description = "서버 오류 발생")
+    })
+    @PostMapping("/logout")
+    public ResponseEntity<Void> signOut(HttpServletResponse response, @AuthenticatedUserId String userId) {
+        signOutService.signOut(response, userId);
+        return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * 회원탈퇴 요청을 처리합니다.
+     *
+     * @param userId 현재 로그인 중인 사용자 ID
+     * @return HTTP 상태 코드 204 (No Content) 회원탈퇴 성공
+     */
+    @Operation(
+            summary = "회원탈퇴",
+            description = "현재 로그인 중인 사용자가 자신의 계정을 탈퇴합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "회원탈퇴 성공"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 요청 또는 인증 실패"),
+            @ApiResponse(responseCode = "500", description = "서버 오류 발생")
+    })
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("/withdraw")
+    public ResponseEntity<Void> withdraw(@AuthenticatedUserId String userId){
+        blogUserWithdrawService.withdrawBlogUser(userId);
+        blogWithdrawService.withdraw(userId);
+        return ResponseEntity.noContent().build();
+    }
 
 }

--- a/module-api/src/main/java/com/study/api/blogUser/service/BlogUserSignOutService.java
+++ b/module-api/src/main/java/com/study/api/blogUser/service/BlogUserSignOutService.java
@@ -1,0 +1,29 @@
+package com.study.api.blogUser.service;
+
+import com.study.api.jwt.TokenType;
+import com.study.common.utill.CookieUtil;
+import com.study.domain.redis.CookieProperties;
+import com.study.domain.redis.refreshToken.repository.RefreshTokenCommand;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BlogUserSignOutService {
+
+    private final RefreshTokenCommand refreshTokenCommand;
+    private final CookieProperties cookieProperties;
+
+    public void signOut(HttpServletResponse response, String userId) {
+        refreshTokenCommand.deleteById(userId);
+        deleteTokenCookie(response, TokenType.REFRESH);
+    }
+
+    private void deleteTokenCookie(
+            HttpServletResponse response,
+            TokenType tokenType
+    ) {
+        CookieUtil.deleteCookie(response, tokenType.name(), cookieProperties.getDomain());
+    }
+}

--- a/module-api/src/main/java/com/study/api/blogUser/service/BlogUserWithdrawService.java
+++ b/module-api/src/main/java/com/study/api/blogUser/service/BlogUserWithdrawService.java
@@ -1,0 +1,23 @@
+package com.study.api.blogUser.service;
+
+import com.study.common.exception.user.NotFoundUserException;
+import com.study.domain.blogUser.entity.BlogUser;
+import com.study.domain.mapper.bloguser.BlogUserCommandMapper;
+import com.study.domain.mapper.bloguser.BlogUserQueryMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class BlogUserWithdrawService {
+
+    private final BlogUserQueryMapper blogUserQueryMapper;
+    private final BlogUserCommandMapper blogUserCommandMapper;
+
+    @Transactional
+    public void withdrawBlogUser(String userId) {
+        BlogUser blogUser = blogUserQueryMapper.findBlogUserByUserId(userId).orElseThrow(() -> new NotFoundUserException(userId));
+        blogUserCommandMapper.withdraw(blogUser);
+    }
+}

--- a/module-domain/src/main/java/com/study/domain/mapper/bloguser/BlogUserCommandMapper.java
+++ b/module-domain/src/main/java/com/study/domain/mapper/bloguser/BlogUserCommandMapper.java
@@ -10,6 +10,6 @@ public interface BlogUserCommandMapper {
 
     long save(@Param("blogUser") BlogUser blogUser);
 
-
+    void withdraw(@Param("blogUser") BlogUser blogUser);
 
 }

--- a/module-domain/src/main/resources/mybatis/mapper/blogUser/BlogUserCommandMapper.xml
+++ b/module-domain/src/main/resources/mybatis/mapper/blogUser/BlogUserCommandMapper.xml
@@ -30,4 +30,7 @@
         )
     </insert>
 
+    <update id="withdraw" parameterType="com.study.domain.blogUser.entity.BlogUser">
+        UPDATE bloguser SET deleted_at = NOW() WHERE userId = #{blogUser.userId}
+    </update>
 </mapper>


### PR DESCRIPTION
### 연관 Issue 정보
> - #14 

### 작업 내용 요약
- [x] 로그아웃 시 JWT토큰을 처리한다.
- [x] 회원탈퇴 시 블로그와 회원을 처리한다.

### 작업 상세 내용
- 로그아웃 시 엑세스토큰은 프론트에서 삭제하고, 리프레쉬토큰은 레디스에서 삭제한다. 또한 deleteTokenCookie메서드를 사용해서 리프레쉬토큰이 담긴 쿠키도 삭제한다.
![image](https://github.com/user-attachments/assets/b08cf034-41ea-410e-84c4-e133cec8439b)
![image](https://github.com/user-attachments/assets/8800d4f3-4a76-4f7d-8f74-f323875a05c9)


2. 회원탈퇴 시 회원과 블로그의 삭제날짜(delete_at)를 현재날짜와 시간으로 저장한다.  삭제날짜에 데이터가 저장되어 있는 경우, 삭제되었다고 판단한다.
![image](https://github.com/user-attachments/assets/f4f6a00f-91a9-47ba-8c9b-1b911cb26dab)
![image](https://github.com/user-attachments/assets/8a9b9c53-5ab3-478c-8fdf-2e81c5e8e44f)
