### PR TITLE
feat: #21 게시글의 좋아요 추가, 취소 기능을 구현한다.

### DIFF
--- a/module-api/src/main/java/com/study/api/liked/controller/LikedController.java
+++ b/module-api/src/main/java/com/study/api/liked/controller/LikedController.java
@@ -1,0 +1,54 @@
+package com.study.api.liked.controller;
+
+import com.study.api.liked.service.LikedService;
+import com.study.api.config.annotation.AuthenticatedUserId;
+import com.study.domain.mapper.post.PostCommandMapper;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * 좋아요 관련 요청을 처리하는 컨트롤러입니다.
+ */
+@RestController
+@RequestMapping("/liked")
+@RequiredArgsConstructor
+public class LikedController {
+
+    private final LikedService likedService;
+    private final PostCommandMapper postCommandMapper;
+
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "400", description = "좋아요 추가에 실패했습니다")
+    })
+    @Operation(
+            method = "POST",
+            summary = "좋아요 추가",
+            description = "좋아요를 추가한다."
+    )
+    @PostMapping("/addLike")
+    public ResponseEntity<Void> addLike(@RequestParam int postId, @AuthenticatedUserId String userId) {
+        likedService.addLike(postId, userId);
+        return ResponseEntity.ok().build();
+    }
+
+
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "400", description = "좋아요 취소에 실패했습니다")
+    })
+    @Operation(
+            method = "DELETE",
+            summary = "좋아요 취소",
+            description = "좋아요를 취소한다."
+    )
+    @DeleteMapping("/deleteLike")
+    public ResponseEntity<Void> deleteLike(@RequestParam int postId, @AuthenticatedUserId String userId) {
+        likedService.minusLike(postId, userId);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/module-api/src/main/java/com/study/api/liked/service/LikedService.java
+++ b/module-api/src/main/java/com/study/api/liked/service/LikedService.java
@@ -1,0 +1,65 @@
+package com.study.api.liked.service;
+
+import com.study.common.exception.ErrorCode;
+import com.study.common.exception.liked.PostDeleteLikeException;
+import com.study.common.exception.liked.PostLikedException;
+import com.study.common.exception.post.NotExistPostException;
+import com.study.common.exception.user.NotFoundUserException;
+import com.study.domain.blogUser.entity.BlogUser;
+import com.study.domain.liked.entity.Liked;
+import com.study.domain.mapper.bloguser.BlogUserQueryMapper;
+import com.study.domain.mapper.liked.LikedCommandMapper;
+import com.study.domain.mapper.liked.LikedQueryMapper;
+import com.study.domain.mapper.post.PostCommandMapper;
+import com.study.domain.mapper.post.PostQueryMapper;
+import com.study.domain.post.entity.Post;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LikedService {
+
+    private final LikedQueryMapper likedQueryMapper;
+    private final LikedCommandMapper likedCommandMapper;
+    private final PostQueryMapper postQueryMapper;
+    private final PostCommandMapper postCommandMapper;
+    private final BlogUserQueryMapper blogUserQueryMapper;
+
+    @Transactional
+    public void addLike(int postId, String userId) {
+
+        Post post = postQueryMapper.findPostById(postId).orElseThrow(NotExistPostException::new);
+        BlogUser blogUser = blogUserQueryMapper.findBlogUserByUserId(userId).orElseThrow(() -> new NotFoundUserException(userId));
+
+        if (!checkLikeExist(blogUser, post)) {
+            likedCommandMapper.save(new Liked(blogUser.getUserId(), post.getId()));
+            post.plusLikedCount();
+            postCommandMapper.addLike(postId);
+        } else {
+            throw new PostLikedException(ErrorCode.POST_LIKE_FAIL_EXCEPTION);
+        }
+    }
+
+    @Transactional
+    public void minusLike(int postId, String userId) {
+        Post post = postQueryMapper.findPostById(postId).orElseThrow(NotExistPostException::new);
+        BlogUser blogUser = blogUserQueryMapper.findBlogUserByUserId(userId).orElseThrow(() -> new NotFoundUserException(userId));
+
+        if (checkLikeExist(blogUser, post)) {
+            likedCommandMapper.deleteLikesByUserAndPost(blogUser, post);
+            post.minusLikedCount();
+            postCommandMapper.minusLike(postId);
+        } else {
+            throw new PostDeleteLikeException(ErrorCode.POST_DELETE_LIKE_FAIL_EXCEPTION);
+        }
+    }
+
+    private boolean checkLikeExist(BlogUser user, Post post) {
+        return likedQueryMapper.existsByUserAndPost(user, post);
+    }
+}
+

--- a/module-common/src/main/java/com/study/common/exception/liked/LikedException.java
+++ b/module-common/src/main/java/com/study/common/exception/liked/LikedException.java
@@ -1,0 +1,11 @@
+package com.study.common.exception.liked;
+
+import com.study.common.exception.BusinessException;
+import com.study.common.exception.ErrorCode;
+
+public class LikedException extends BusinessException {
+
+    public LikedException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/module-common/src/main/java/com/study/common/exception/liked/PostDeleteLikeException.java
+++ b/module-common/src/main/java/com/study/common/exception/liked/PostDeleteLikeException.java
@@ -1,0 +1,9 @@
+package com.study.common.exception.liked;
+
+import com.study.common.exception.ErrorCode;
+
+public class PostDeleteLikeException extends LikedException{
+    public PostDeleteLikeException(ErrorCode errorCode) {
+            super(ErrorCode.POST_DELETE_LIKE_FAIL_EXCEPTION);
+        }
+    }

--- a/module-common/src/main/java/com/study/common/exception/liked/PostLikedException.java
+++ b/module-common/src/main/java/com/study/common/exception/liked/PostLikedException.java
@@ -1,0 +1,11 @@
+package com.study.common.exception.liked;
+
+import com.study.common.exception.ErrorCode;
+
+public class PostLikedException extends LikedException{
+
+    public PostLikedException(ErrorCode errorCode) {
+        super(ErrorCode.POST_LIKE_FAIL_EXCEPTION);
+    }
+
+}

--- a/module-domain/src/main/java/com/study/domain/liked/entity/Liked.java
+++ b/module-domain/src/main/java/com/study/domain/liked/entity/Liked.java
@@ -1,0 +1,16 @@
+package com.study.domain.liked.entity;
+
+import lombok.Getter;
+
+@Getter
+public class Liked {
+
+    private int id;
+    private String userId;
+    private long postId;
+
+    public Liked(String userId, long postId) {
+        this.userId = userId;
+        this.postId = postId;
+    }
+}

--- a/module-domain/src/main/java/com/study/domain/mapper/liked/LikedCommandMapper.java
+++ b/module-domain/src/main/java/com/study/domain/mapper/liked/LikedCommandMapper.java
@@ -1,0 +1,17 @@
+package com.study.domain.mapper.liked;
+
+import com.study.domain.blogUser.entity.BlogUser;
+import com.study.domain.liked.entity.Liked;
+import com.study.domain.post.entity.Post;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+@Mapper
+public interface LikedCommandMapper {
+
+    void save(Liked liked);
+
+    void deleteLikesByUserAndPost(@Param("user") BlogUser user, @Param("post") Post post);
+
+
+}

--- a/module-domain/src/main/java/com/study/domain/mapper/liked/LikedQueryMapper.java
+++ b/module-domain/src/main/java/com/study/domain/mapper/liked/LikedQueryMapper.java
@@ -1,0 +1,13 @@
+package com.study.domain.mapper.liked;
+
+import com.study.domain.blogUser.entity.BlogUser;
+import com.study.domain.post.entity.Post;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+@Mapper
+public interface LikedQueryMapper {
+
+    boolean existsByUserAndPost(@Param("user") BlogUser user, @Param("post") Post post);
+
+}

--- a/module-domain/src/main/java/com/study/domain/mapper/post/PostCommandMapper.java
+++ b/module-domain/src/main/java/com/study/domain/mapper/post/PostCommandMapper.java
@@ -27,4 +27,8 @@ public interface PostCommandMapper {
 
     void deleteByPostId(Post post);
 
+    void minusLike(@Param("postId") long postId);
+
+    void addLike(@Param("postId") long postId);
+
 }

--- a/module-domain/src/main/java/com/study/domain/post/entity/Post.java
+++ b/module-domain/src/main/java/com/study/domain/post/entity/Post.java
@@ -24,6 +24,7 @@ public class Post {
     private String content;
     private String nickName;
     private List<String> fileUrls;
+    private int likeCount;
     private LocalDateTime createdDate;
     private LocalDateTime modifiedDate;
     private LocalDateTime deletedDate;
@@ -36,6 +37,7 @@ public class Post {
             String title,
             String content,
             List<String> fileUrls,
+            int likeCount,
             LocalDateTime createdDate,
             LocalDateTime modifiedDate,
             LocalDateTime deletedDate
@@ -46,6 +48,7 @@ public class Post {
         this.title = title;
         this.content = content;
         this.fileUrls = fileUrls;
+        this.likeCount = likeCount;
         this.createdDate = LocalDateTime.now();
         this.modifiedDate = null;
         this.deletedDate = null;
@@ -60,7 +63,16 @@ public class Post {
                 .content(postRegisterDto.content())
                 .fileUrls(fileUrls)
                 .createdDate(LocalDateTime.now())
+                .likeCount(0)
                 .build();
+    }
+
+    public void plusLikedCount() {
+        likeCount = likeCount + 1;
+    }
+
+    public void minusLikedCount() {
+        likeCount = likeCount - 1;
     }
 
 }

--- a/module-domain/src/main/resources/mybatis/mapper/liked/LikedCommandMapper.xml
+++ b/module-domain/src/main/resources/mybatis/mapper/liked/LikedCommandMapper.xml
@@ -1,0 +1,15 @@
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.study.domain.mapper.liked.LikedCommandMapper">
+
+    <insert id="save" parameterType="com.study.domain.liked.entity.Liked">
+        INSERT INTO liked (userId, post_id)
+        VALUES (#{userId}, #{postId})
+    </insert>
+
+    <!-- 사용자 ID와 게시물 ID를 기반으로 좋아요 삭제 -->
+    <delete id="deleteLikesByUserAndPost" parameterType="map">
+        DELETE FROM liked
+        WHERE userId = #{user.userId}
+          AND post_id = #{post.id}
+    </delete>
+</mapper>

--- a/module-domain/src/main/resources/mybatis/mapper/liked/LikedQueryMapper.xml
+++ b/module-domain/src/main/resources/mybatis/mapper/liked/LikedQueryMapper.xml
@@ -1,0 +1,12 @@
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.study.domain.mapper.liked.LikedQueryMapper">
+
+    <!-- 사용자 ID와 게시물 ID를 기반으로 좋아요 존재 여부 확인 -->
+    <select id="existsByUserAndPost" resultType="boolean">
+        SELECT CASE WHEN COUNT(*) > 0 THEN TRUE ELSE FALSE END
+        FROM liked
+        WHERE userId = #{user.userId}
+          AND post_id = #{post.id}
+    </select>
+
+</mapper>

--- a/module-domain/src/main/resources/mybatis/mapper/post/PostCommandMapper.xml
+++ b/module-domain/src/main/resources/mybatis/mapper/post/PostCommandMapper.xml
@@ -59,4 +59,17 @@
     <update id="deleteByPostId" parameterType="com.study.domain.post.entity.Post">
         UPDATE post SET deleted_at = NOW() where id = #{postId}
     </update>
+
+    <update id="addLike" parameterType="long">
+        UPDATE post
+        SET liked_count  = liked_count + 1
+        WHERE id = #{postId}
+    </update>
+
+    <update id="minusLike" parameterType="long">
+        UPDATE post
+        SET liked_count  = liked_count - 1
+        WHERE id = #{postId}
+    </update>
+
 </mapper>


### PR DESCRIPTION
### 연관 Issue 정보
> - #21

### 작업 내용 요약
- [x] 게시글의 좋아요 추가
- [x] 게시글의 좋아요 취소
- [x] 좋아요 기능 관련 예외처리  
- [x] Post 클래스에 좋아요 관련 필드와 메서드 추가
- [x] Post 매퍼 클래스에 좋아요를 증가, 감소시키는 매서드 추가

### 작업 상세 내용
1. 한 명의 회원은 '좋아요' 한 번만 증가시킬 수 있으며, 다시 실행하면 좋아요가 취소된다.