### PR TITLE
feat: #25 인기 게시글을 레디스에 저장하고, 조회하는 기능을 구현한다.

### DIFF
--- a/module-api/src/main/java/com/study/api/post/controller/PostController.java
+++ b/module-api/src/main/java/com/study/api/post/controller/PostController.java
@@ -1,8 +1,8 @@
 package com.study.api.post.controller;
 
 
-import com.study.api.config.annotation.AuthenticatedUserId;
 import com.study.api.post.service.PostService;
+import com.study.api.config.annotation.AuthenticatedUserId;
 import com.study.domain.post.dto.PagingResponse;
 import com.study.domain.post.dto.PostDto;
 import com.study.domain.post.dto.SearchDto;
@@ -123,5 +123,23 @@ public class PostController {
     public ResponseEntity<PagingResponse<PostDto.PostListDto>> getPostList(SearchDto params) {
         PagingResponse<PostDto.PostListDto> postList = postService.getPostList(params);
         return ResponseEntity.ok(postList);
+    }
+
+
+    @Operation(
+            method = "GET",
+            summary = "인기글 게시글 리스트 조회",
+            description = "좋아요기 10개 이상인 인기글 게시글 리스트를 가지고 온다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "인기글 게시글 리스트 조회 성공",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = PostDto.PostListDto.class))),
+            @ApiResponse(responseCode = "400", description = "인기글 게시글 리스트 조회에 실패했습니다.", content = @Content)
+    })
+    @GetMapping("/popular")
+    public ResponseEntity<PagingResponse<PostDto.PostListDto>> getPopularPosts(SearchDto params) {
+        PagingResponse<PostDto.PostListDto> popularPosts = postService.getPopularPosts(params);
+        return ResponseEntity.ok(popularPosts);
     }
 }

--- a/module-domain/src/main/java/com/study/domain/mapper/post/PostCommandMapper.java
+++ b/module-domain/src/main/java/com/study/domain/mapper/post/PostCommandMapper.java
@@ -31,6 +31,8 @@ public interface PostCommandMapper {
 
     void addLike(@Param("postId") long postId);
 
+    void updatePopular(@Param("postId") long postId, @Param("isPopular") boolean isPopular);
+
     void addCommentCount(@Param("postId") long postId);
 
     void minusCommentCount(@Param("postId") long postId);

--- a/module-domain/src/main/java/com/study/domain/post/dto/PostDto.java
+++ b/module-domain/src/main/java/com/study/domain/post/dto/PostDto.java
@@ -2,11 +2,13 @@ package com.study.domain.post.dto;
 
 import com.study.domain.comment.dto.CommentDto;
 import com.study.domain.post.entity.Post;
+import com.study.domain.redis.popularPost.entity.PopularPost;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Post에 대한 데이터 전송 객체(DTO)입니다.
@@ -61,7 +63,8 @@ public class PostDto {
             List<String> fileUrls,
             List<CommentDto.CommentResponseDto> commentResponseDtos,
             int likeCount,
-            int commentCount
+            int commentCount,
+            boolean isPopular
     ) {
 
         public static PostResponse fromPost(Post post, List<CommentDto.CommentResponseDto> commentResponseDtos, List<String> fileUrls) {
@@ -73,6 +76,27 @@ public class PostDto {
                     .userId(post.getUserId())
                     .commentResponseDtos(commentResponseDtos)
                     .likeCount(post.getLikeCount())
+                    .isPopular(false)
+                    .build();
+        }
+
+        public static PostResponse fromPopularPost(PopularPost popularPost) {
+            List<CommentDto.CommentResponseDto> commentResponseDtoList = popularPost.getComments().stream().map(
+                    CommentDto.CommentResponseDto::of
+            ).collect(Collectors.toList());
+
+            return PostResponse.builder()
+                    .postId(popularPost.getPostId())
+                    .title(popularPost.getTitle())
+                    .content(popularPost.getContent())
+                    .fileUrls(popularPost.getFileUrls())
+                    .userId(popularPost.getUserId())
+                    .commentResponseDtos(commentResponseDtoList)
+                    .likeCount(popularPost.getLikeCount())
+                    .commentCount(popularPost.getCommentCount())
+                    .isPopular(true)
+                    .likeCount(popularPost.getLikeCount())
+                    .commentCount(popularPost.getCommentCount())
                     .build();
         }
     }

--- a/module-domain/src/main/java/com/study/domain/post/entity/Post.java
+++ b/module-domain/src/main/java/com/study/domain/post/entity/Post.java
@@ -28,6 +28,7 @@ public class Post {
     private List<Comment> comments = new ArrayList<>();
     private int likeCount;
     private int commentCount;
+    private boolean isPopular;
     private LocalDateTime createdDate;
     private LocalDateTime modifiedDate;
     private LocalDateTime deletedDate;
@@ -42,6 +43,7 @@ public class Post {
             List<String> fileUrls,
             List<Comment> comments,
             int likeCount,
+            boolean isPopular,
             int commentCount,
             LocalDateTime createdDate,
             LocalDateTime modifiedDate,
@@ -55,6 +57,7 @@ public class Post {
         this.fileUrls = fileUrls;
         this.comments = comments;
         this.likeCount = likeCount;
+        this.isPopular = isPopular;
         this.commentCount = commentCount;
         this.createdDate = LocalDateTime.now();
         this.modifiedDate = null;
@@ -70,6 +73,7 @@ public class Post {
                 .content(postRegisterDto.content())
                 .fileUrls(fileUrls)
                 .createdDate(LocalDateTime.now())
+                .isPopular(false)
                 .commentCount(0)
                 .likeCount(0)
                 .build();
@@ -86,5 +90,4 @@ public class Post {
     public void minusLikedCount() {
         likeCount = likeCount - 1;
     }
-
 }

--- a/module-domain/src/main/java/com/study/domain/redis/popularPost/entity/PopularPost.java
+++ b/module-domain/src/main/java/com/study/domain/redis/popularPost/entity/PopularPost.java
@@ -1,0 +1,68 @@
+package com.study.domain.redis.popularPost.entity;
+
+import com.study.domain.comment.entity.Comment;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@RedisHash(value = "PopularPost", timeToLive = 86400)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PopularPost {
+
+    @Id
+    private long postId;
+    private long blogId;
+    private String userId;
+    private String title;
+    private String content;
+    private String nickName;
+    private List<String> fileUrls;
+    private List<Comment> comments;
+    private int likeCount;
+    private int commentCount;
+    private boolean isPopular;
+    private LocalDateTime createdDate;
+    private LocalDateTime modifiedDate;
+    private LocalDateTime deletedDate;
+
+
+    @Builder
+    public PopularPost(
+            long postId,
+            long blogId,
+            String userId,
+            String title,
+            String content,
+            String nickName,
+            List<String> fileUrls,
+            List<Comment> comments,
+            int likeCount,
+            int commentCount,
+            boolean isPopular,
+            LocalDateTime createdDate,
+            LocalDateTime modifiedDate,
+            LocalDateTime deletedDate
+    ) {
+        this.postId = postId;
+        this.blogId = blogId;
+        this.userId = userId;
+        this.title = title;
+        this.content = content;
+        this.nickName = nickName;
+        this.fileUrls = fileUrls;
+        this.comments = comments;
+        this.likeCount = likeCount;
+        this.commentCount = commentCount;
+        this.isPopular = isPopular;
+        this.createdDate = LocalDateTime.now();
+        this.modifiedDate = null;
+        this.deletedDate = null;
+    }
+}

--- a/module-domain/src/main/java/com/study/domain/redis/popularPost/service/PopularPostCacheService.java
+++ b/module-domain/src/main/java/com/study/domain/redis/popularPost/service/PopularPostCacheService.java
@@ -1,0 +1,66 @@
+package com.study.domain.redis.popularPost.service;
+
+import com.study.domain.comment.entity.Comment;
+import com.study.domain.mapper.comment.CommentQueryMapper;
+import com.study.domain.mapper.post.PostQueryMapper;
+import com.study.domain.post.dto.PostDto;
+import com.study.domain.post.entity.Post;
+import com.study.domain.redis.popularPost.entity.PopularPost;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+
+@Service
+@RequiredArgsConstructor
+public class PopularPostCacheService {
+
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final PostQueryMapper postQueryMapper;
+    private final CommentQueryMapper commentQueryMapper;
+
+    private final String POPULAR_POST_KEY = "popularPost:";
+
+    public void cachePopularPost(Post post) {
+        String key = POPULAR_POST_KEY + post.getId();
+
+        List<String> fileUrls = postQueryMapper.findFileUrlsByPostId(post.getId());
+        List<Comment> comments = commentQueryMapper.getCommentsByPostId(post.getId());
+
+        // PopularPost 객체 생성
+        PopularPost popularPost = createPopularPost(post, fileUrls, comments);
+
+        PostDto.PostResponse postResponse = PostDto.PostResponse.fromPopularPost(popularPost);
+        redisTemplate.opsForValue().set(key, postResponse);
+    }
+
+
+    public PostDto.PostResponse getCachedPopularPost(long postId) {
+        return (PostDto.PostResponse) redisTemplate.opsForValue().get(POPULAR_POST_KEY + postId);
+    }
+
+    public void removePopularPostCache(long postId) {
+        redisTemplate.delete(POPULAR_POST_KEY + postId);
+    }
+
+    private static PopularPost createPopularPost(Post post, List<String> fileUrls, List<Comment> comments) {
+        PopularPost popularPost = PopularPost.builder()
+                .postId(post.getId())
+                .blogId(post.getBlogId())
+                .userId(post.getUserId())
+                .title(post.getTitle())
+                .content(post.getContent())
+                .nickName(post.getNickName())
+                .fileUrls(fileUrls)
+                .comments(comments)
+                .likeCount(post.getLikeCount())
+                .commentCount(post.getCommentCount())
+                .createdDate(post.getCreatedDate())
+                .modifiedDate(post.getModifiedDate())
+                .build();
+        return popularPost;
+    }
+}

--- a/module-domain/src/main/resources/mybatis/mapper/post/PostCommandMapper.xml
+++ b/module-domain/src/main/resources/mybatis/mapper/post/PostCommandMapper.xml
@@ -72,6 +72,13 @@
         WHERE id = #{postId}
     </update>
 
+
+    <update id="updatePopular">
+        UPDATE post
+        SET is_popular = #{isPopular}
+        WHERE id = #{postId}
+    </update>
+
     <update id="addCommentCount">
         UPDATE post
         SET comment_count = comment_count + 1


### PR DESCRIPTION
### 연관 Issue 정보

> - #25 

### 작업 내용 요약
- [x] 일정 수 이상의 추천을 받은 게시글을 Redis에 저장한다.
- [x] 게시글을 조회할 때, Redis에 저장되어있는지 확인하고, 저장되어 있다면 반환한다.
- [x] Post 관련 코드에 인기게시글에 관한 코드를 추가한다.

### 작업 상세 내용
1. 일정 수 이상의 추천을 받은 게시글은 인기 게시글로 자주 조회될 것을 예상해서 Redis에 저장한다. 그리고 게시글을 조회할 때, Redis에 저장되어 있다면 Redis에서, 없다면 DB에서 반환한다.