### PR TITLE
feat: #28 게시글을 조회할 때마다 게시글의 조회 수가 증가한다.

### DIFF
--- a/module-api/src/main/java/com/study/api/post/service/PostService.java
+++ b/module-api/src/main/java/com/study/api/post/service/PostService.java
@@ -46,7 +46,7 @@ public class PostService {
     private final PopularPostCacheService popularPostCacheService;
 
     @Transactional
-    public PostDto.PostResponse register(@Valid PostDto.PostRegisterDto postRegisterDto, List<MultipartFile> files, String userId) {
+    public PostDto.PostResponse register(@Valid PostDto.PostRegisterDto postRegisterDto, List<MultipartFile> files, List<String> tags, String userId) {
 
         BlogUser blogUser = blogUserQueryMapper.findBlogUserByUserId(userId).orElseThrow(() -> new NotFoundUserException(userId));
         Blog blog = blogQueryMapper.findBlogByUserId(userId);
@@ -72,7 +72,7 @@ public class PostService {
 
 
     @Transactional
-    public PostDto.PostResponse update(@Valid PostDto.UpdatePostDto updatePostDto, List<MultipartFile> files, String userId, long postId) {
+    public PostDto.PostResponse update(@Valid PostDto.UpdatePostDto updatePostDto, List<MultipartFile> files, List<String> tags, String userId, long postId) {
 
         Post post = postQueryMapper.findPostById(postId).orElseThrow(NotExistPostException::new);
 
@@ -114,6 +114,7 @@ public class PostService {
         PostDto.PostResponse cachedPopularPost = popularPostCacheService.getCachedPopularPost(postId);
         if (cachedPopularPost != null) {
             log.info("get cachedPopularPost = {}", cachedPopularPost);
+            postCommandMapper.plusViewCount(postId);
             return popularPostCacheService.getCachedPopularPost(postId);
         }
 
@@ -125,6 +126,7 @@ public class PostService {
                 .map(CommentDto.CommentResponseDto::of)
                 .collect(Collectors.toList());
 
+        postCommandMapper.plusViewCount(postId);
         return PostDto.PostResponse.fromPost(post, commentResponseDtos, fileUrls);
     }
 

--- a/module-domain/src/main/java/com/study/domain/mapper/post/PostCommandMapper.java
+++ b/module-domain/src/main/java/com/study/domain/mapper/post/PostCommandMapper.java
@@ -36,4 +36,6 @@ public interface PostCommandMapper {
     void addCommentCount(@Param("postId") long postId);
 
     void minusCommentCount(@Param("postId") long postId);
+
+    void plusViewCount(@Param("postId") long postId);
 }

--- a/module-domain/src/main/java/com/study/domain/post/dto/PostDto.java
+++ b/module-domain/src/main/java/com/study/domain/post/dto/PostDto.java
@@ -64,6 +64,7 @@ public class PostDto {
             List<CommentDto.CommentResponseDto> commentResponseDtos,
             int likeCount,
             int commentCount,
+            int viewCount,
             boolean isPopular
     ) {
 
@@ -76,6 +77,7 @@ public class PostDto {
                     .userId(post.getUserId())
                     .commentResponseDtos(commentResponseDtos)
                     .likeCount(post.getLikeCount())
+                    .viewCount(post.getViewCount())
                     .isPopular(false)
                     .build();
         }
@@ -94,6 +96,7 @@ public class PostDto {
                     .commentResponseDtos(commentResponseDtoList)
                     .likeCount(popularPost.getLikeCount())
                     .commentCount(popularPost.getCommentCount())
+                    .viewCount(popularPost.getViewCount())
                     .isPopular(true)
                     .likeCount(popularPost.getLikeCount())
                     .commentCount(popularPost.getCommentCount())
@@ -109,6 +112,7 @@ public class PostDto {
             String nickName,
             int likeCount,
             int commentCount,
+            int viewCount,
             LocalDateTime createdDate
     ) {
         public static PostListDto of(Post post) {
@@ -119,6 +123,7 @@ public class PostDto {
                     .nickName(post.getNickName())
                     .likeCount(post.getLikeCount())
                     .commentCount(post.getCommentCount())
+                    .viewCount(post.getViewCount())
                     .build();
         }
     }

--- a/module-domain/src/main/java/com/study/domain/post/entity/Post.java
+++ b/module-domain/src/main/java/com/study/domain/post/entity/Post.java
@@ -28,6 +28,7 @@ public class Post {
     private List<Comment> comments = new ArrayList<>();
     private int likeCount;
     private int commentCount;
+    private int viewCount;
     private boolean isPopular;
     private LocalDateTime createdDate;
     private LocalDateTime modifiedDate;
@@ -45,6 +46,7 @@ public class Post {
             int likeCount,
             boolean isPopular,
             int commentCount,
+            int viewCount,
             LocalDateTime createdDate,
             LocalDateTime modifiedDate,
             LocalDateTime deletedDate
@@ -75,6 +77,7 @@ public class Post {
                 .createdDate(LocalDateTime.now())
                 .isPopular(false)
                 .commentCount(0)
+                .viewCount(0)
                 .likeCount(0)
                 .build();
     }
@@ -89,5 +92,9 @@ public class Post {
 
     public void minusLikedCount() {
         likeCount = likeCount - 1;
+    }
+
+    public void plusVieCount(){
+        viewCount = viewCount + 1;
     }
 }

--- a/module-domain/src/main/java/com/study/domain/redis/popularPost/entity/PopularPost.java
+++ b/module-domain/src/main/java/com/study/domain/redis/popularPost/entity/PopularPost.java
@@ -27,6 +27,7 @@ public class PopularPost {
     private List<Comment> comments;
     private int likeCount;
     private int commentCount;
+    private int viewCount;
     private boolean isPopular;
     private LocalDateTime createdDate;
     private LocalDateTime modifiedDate;
@@ -45,6 +46,7 @@ public class PopularPost {
             List<Comment> comments,
             int likeCount,
             int commentCount,
+            int viewCount,
             boolean isPopular,
             LocalDateTime createdDate,
             LocalDateTime modifiedDate,
@@ -60,6 +62,7 @@ public class PopularPost {
         this.comments = comments;
         this.likeCount = likeCount;
         this.commentCount = commentCount;
+        this.viewCount = viewCount;
         this.isPopular = isPopular;
         this.createdDate = LocalDateTime.now();
         this.modifiedDate = null;

--- a/module-domain/src/main/resources/mybatis/mapper/post/PostCommandMapper.xml
+++ b/module-domain/src/main/resources/mybatis/mapper/post/PostCommandMapper.xml
@@ -90,4 +90,11 @@
         SET comment_count = comment_count - 1
         WHERE id = #{postId}
     </update>
+
+    <update id="plusViewCount">
+        UPDATE post
+        SET view_count = view_count + 1
+        WHERE id = #{postId}
+    </update>
+
 </mapper>


### PR DESCRIPTION
### 연관 Issue 정보

> - #28 

### 작업 내용 요약
- [x] 조회 수 컬럼 추가
- [x] 조회 수 증가 로직 추가

### 작업 상세 내용
> 게시글, 인기게시글에 viewCount 필드를 추가하고, 조회 로직이 실행될 때마다 viewCount 가 증가할 수 있게 매퍼클래스에 로직을 추가한다.

1. viewCount 필드 추가
![image](https://github.com/user-attachments/assets/462c623a-1c9b-49f0-92f2-9eff971e8e19)


2. 매퍼파일에 게시글 조회 시 조회수(viewCount)를 증가시키는 코드를 추가한다.
![image](https://github.com/user-attachments/assets/f5423447-a8d0-4a01-aa03-9297cd4089d4)
![image](https://github.com/user-attachments/assets/af6ffece-1685-408e-bc0b-291e790f8aa5)

3. 서비스로직에 게시글 조회 시 조회수(viewCount)를 증가시키는 코드를 추가한다.
 `postCommandMapper.plusViewCount(postId);`
![image](https://github.com/user-attachments/assets/9312280b-d90c-492b-9f61-ecbd2a4b341d)

