### PR TITLE
feat: #30 게시글의 태그를 등록, 수정, 삭제하는 기능을 구현한다. 

### DIFF
--- a/module-api/src/main/java/com/study/api/post/controller/PostController.java
+++ b/module-api/src/main/java/com/study/api/post/controller/PostController.java
@@ -44,9 +44,10 @@ public class PostController {
     public ResponseEntity<PostDto.PostResponse> register(
             @RequestPart @Valid PostDto.PostRegisterDto postRegisterDto,
             @RequestPart(required = false) List<MultipartFile> files,
+            @RequestPart(required = false) List<String> tags,
             @AuthenticatedUserId String userId
     ){
-         return ResponseEntity.ok(postService.register(postRegisterDto, files, userId));
+        return ResponseEntity.ok(postService.register(postRegisterDto, files, tags, userId));
     }
 
     @Operation(
@@ -65,10 +66,11 @@ public class PostController {
     public ResponseEntity<PostDto.PostResponse> update(
             @RequestPart @Valid PostDto.UpdatePostDto updatePostDto,
             @RequestPart(required = false) List<MultipartFile> files,
+            @RequestPart(required = false) List<String> tags,
             @AuthenticatedUserId String userId,
             @PathVariable Long postId
     ){
-        PostDto.PostResponse updatedPost = postService.update(updatePostDto, files, userId, postId);
+        PostDto.PostResponse updatedPost = postService.update(updatePostDto, files, tags, userId, postId);
         return ResponseEntity.ok(updatedPost);
     }
 

--- a/module-domain/src/main/java/com/study/domain/mapper/postTag/PostTagCommandMapper.java
+++ b/module-domain/src/main/java/com/study/domain/mapper/postTag/PostTagCommandMapper.java
@@ -1,0 +1,14 @@
+package com.study.domain.mapper.postTag;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+@Mapper
+public interface PostTagCommandMapper {
+
+    void registerPostTags(@Param("postId") long postId, @Param("tagIds") List<Integer> tagIds);
+    void deletePostTagsByPostId(long postId);  // 게시글 수정 시 기존 태그 삭제 용도
+
+}

--- a/module-domain/src/main/java/com/study/domain/mapper/tag/TagCommandMapper.java
+++ b/module-domain/src/main/java/com/study/domain/mapper/tag/TagCommandMapper.java
@@ -1,0 +1,12 @@
+package com.study.domain.mapper.tag;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import java.util.List;
+
+@Mapper
+public interface TagCommandMapper {
+
+    void registerTag(@Param("tags") List<String> tags);
+
+}

--- a/module-domain/src/main/java/com/study/domain/mapper/tag/TagQueryMapper.java
+++ b/module-domain/src/main/java/com/study/domain/mapper/tag/TagQueryMapper.java
@@ -1,0 +1,14 @@
+package com.study.domain.mapper.tag;
+
+import org.apache.ibatis.annotations.Mapper;
+
+import java.util.List;
+
+@Mapper
+public interface TagQueryMapper {
+
+    List<Integer> findTagIdsByNames(List<String> tags);
+
+    List<String> findExistingTagNames(List<String> tags);
+
+}

--- a/module-domain/src/main/java/com/study/domain/postTag/entity/PostTag.java
+++ b/module-domain/src/main/java/com/study/domain/postTag/entity/PostTag.java
@@ -1,0 +1,13 @@
+package com.study.domain.postTag.entity;
+
+import lombok.Getter;
+
+/**
+ * 게시글과 태그의 매핑을 나타내는 엔티티 클래스입니다.
+ */
+@Getter
+public class PostTag {
+
+    private long postId;
+    private int tagId;
+}

--- a/module-domain/src/main/java/com/study/domain/tag/entity/Tag.java
+++ b/module-domain/src/main/java/com/study/domain/tag/entity/Tag.java
@@ -1,0 +1,14 @@
+package com.study.domain.tag.entity;
+
+import lombok.Getter;
+
+/**
+ * 게시글 태그 나타내는 엔티티 클래스입니다.
+ */
+@Getter
+public class Tag {
+
+    private int id;
+    private String tagName;
+
+}

--- a/module-domain/src/main/resources/mybatis/mapper/postTag/PostTagCommandMapper.xml
+++ b/module-domain/src/main/resources/mybatis/mapper/postTag/PostTagCommandMapper.xml
@@ -1,0 +1,16 @@
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.study.domain.mapper.postTag.PostTagCommandMapper">
+
+    <!-- 포스트와 태그의 매핑 관계를 등록하는 쿼리 -->
+    <insert id="registerPostTags" parameterType="map">
+        INSERT INTO posttag (post_Id, tag_Id)
+        VALUES
+        <foreach collection="tagIds" item="tagId" separator=",">
+            (#{postId}, #{tagId})
+        </foreach>
+    </insert>
+
+    <delete id="deletePostTagsByPostId">
+        DELETE FROM posttag WHERE post_id = #{postId}
+    </delete>
+</mapper>

--- a/module-domain/src/main/resources/mybatis/mapper/tag/TagCommandMapper.xml
+++ b/module-domain/src/main/resources/mybatis/mapper/tag/TagCommandMapper.xml
@@ -1,0 +1,13 @@
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.study.domain.mapper.tag.TagCommandMapper">
+
+
+    <insert id="registerTag" parameterType="java.util.List">
+        INSERT INTO tag (tagName)
+        VALUES
+        <foreach collection="tags" item="tagName" separator=",">
+            (#{tagName})
+        </foreach>
+    </insert>
+
+</mapper>

--- a/module-domain/src/main/resources/mybatis/mapper/tag/TagQueryMapper.xml
+++ b/module-domain/src/main/resources/mybatis/mapper/tag/TagQueryMapper.xml
@@ -1,0 +1,24 @@
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.study.domain.mapper.tag.TagQueryMapper">
+
+    <!-- 여러 태그 이름에 대한 태그 ID들을 조회하는 쿼리 -->
+    <select id="findTagIdsByNames" resultType="int">
+        SELECT id
+        FROM tag
+        WHERE tagName IN
+        <foreach item="tagName" collection="tags" open="(" separator="," close=")">
+            #{tagName}
+        </foreach>
+    </select>
+
+    <!-- 이미 존재하는 태그 이름을 조회하는 쿼리 -->
+    <select id="findExistingTagNames" resultType="string">
+        SELECT tagName
+        FROM tag
+        WHERE tagName IN
+        <foreach item="tagName" collection="tags" open="(" separator="," close=")">
+            #{tagName}
+        </foreach>
+    </select>
+
+</mapper>


### PR DESCRIPTION
### 연관 Issue 정보
> - #30 

### 작업 내용 요약
- [x] Tag 엔티티, PostTag 엔티티 클래스를 생성한다. 
- [x] Tag 에는 게시글에 등록한 태그와 게시글id, PostTag 테이블에는 게시글 id와 태그id를 저장하는 매퍼파일을 생성한다.
- [x] 게시글에 등록된 태그를 조회하는 매퍼파일을 생성한다.
- [x] 게시글을 등록하거나 수정할 때, 태그를 등록, 수정하는 서비스 로직을 작성한다.

### 작업 상세 내용
- Tag 정보를 저장할 Tag 엔티티 클래스를 생성한다. 
![image](https://github.com/user-attachments/assets/35564fa4-1693-48b7-847f-ede3ae1843ce)

- Post 와 Tag는 다 대 다의 관계이기 때문에 Post 와 Tag의 매핑 클래스 역할을 할 PostTag 클래스를 생성한다.
![image](https://github.com/user-attachments/assets/58aef876-083e-4ec6-bcc6-ecb2dd5bd592)

- Post와 Tag의 매핑을 위해 PostTag 에 postid와 TagId를 저장한다. 태그를 수정할 때는 PostTag 테이블에 등록된 태그는 모두 삭제하고 다시 등록하기 위해 `deletePostTagsByPostId` 메서드를 사용한다.
![image](https://github.com/user-attachments/assets/0b4e4a6e-44ae-4a72-9e56-2f7b98e41235)
![image](https://github.com/user-attachments/assets/dc42a73a-9d8c-47cf-bdfd-c5af2b539749)

- Tag 테이블에 저장된 태그들 또는 태그id를 조회하는 매퍼파일을 생성한다. 게시글에 태그를 등록하거나 수정할 때, 해당 태그들이 게시글에 등록되어있는지 확인하기 위해 사용한다. 
![image](https://github.com/user-attachments/assets/ce826ca6-a3b7-40ac-acc9-7c044cb9bcd6)
![image](https://github.com/user-attachments/assets/8ac07fbd-69c1-4450-921a-a45c7cfb15b4)

- 게시글에 태그를 등록하거나, 게시글을 수정할 때 태그를 등록하는 서비스 로직을 작성한다.
1. 태그 리스트가 비어 있는지 확인하고 비어 있으면 메서드를 종료
2. 입력된 태그 중 데이터베이스에 이미 존재하는 태그 이름들을 조회
3. 기존에 존재하지 않는 태그만 새로운 태그로 필터링하여 등록
4. 태그 ID를 조회하여 포스트와 태그의 매핑 관계를 posttag 테이블에 등록

![image](https://github.com/user-attachments/assets/1cb7cc59-e29e-405c-a52e-16b9d24f166a)
- 게시글을 처음 등록할 때는 게시글에 등록된 태그가 전혀 없으므로 입력한 모든 태그가 등록된다.
![image](https://github.com/user-attachments/assets/b703e7dc-9b7b-4fdc-bf26-02632eacfb33)

- 게시글을 수정할 때는 매핑 테이블인 PostTag 테이블에 등록된 태그들은 모두 삭제하고 다시 입력받은 태그들의 id를 저장한다.
![image](https://github.com/user-attachments/assets/826ed1a9-73fe-420f-a8d2-e57af11b54a3)