### PR TITLE
feat: #32 게시글에 등록된 태그로 게시글을 찾는 기능을 구현한다.

### DIFF
--- a/module-api/src/main/java/com/study/api/post/controller/PostController.java
+++ b/module-api/src/main/java/com/study/api/post/controller/PostController.java
@@ -144,4 +144,22 @@ public class PostController {
         PagingResponse<PostDto.PostListDto> popularPosts = postService.getPopularPosts(params);
         return ResponseEntity.ok(popularPosts);
     }
+
+
+    @Operation(
+            method = "GET",
+            summary = "태그로 게시글 리스트 조회",
+            description = "동일한 태그가 달린 게시글 리스트를 가지고 온다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "태그 게시글 리스트 조회 성공",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = PostDto.PostListDto.class))),
+            @ApiResponse(responseCode = "400", description = "태그 리스트 조회에 실패했습니다.", content = @Content)
+    })
+    @GetMapping("/tag/{tagName}")
+    public ResponseEntity<PagingResponse<PostDto.PostListDto>> getPostsByTag(@PathVariable String tagName, SearchDto params) {
+        PagingResponse<PostDto.PostListDto> postList = postService.getPostsByTag(tagName, params);
+        return ResponseEntity.ok(postList);
+    }
 }

--- a/module-api/src/main/java/com/study/api/post/service/PostService.java
+++ b/module-api/src/main/java/com/study/api/post/service/PostService.java
@@ -34,6 +34,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
+/**
+ * 게시글 관련 비즈니스 로직을 처리하는 서비스 클래스입니다.
+ */
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -51,6 +54,15 @@ public class PostService {
     private final S3Uploader s3Uploader;
     private final PopularPostCacheService popularPostCacheService;
 
+    /**
+     * 게시글을 등록합니다.
+     *
+     * @param postRegisterDto 게시글 등록에 필요한 데이터
+     * @param files 첨부 파일 리스트
+     * @param tags 태그 리스트
+     * @param userId 사용자 ID
+     * @return 등록된 게시글의 응답 데이터
+     */
     @Transactional
     public PostDto.PostResponse register(@Valid PostDto.PostRegisterDto postRegisterDto, List<MultipartFile> files, List<String> tags, String userId) {
 
@@ -78,6 +90,16 @@ public class PostService {
     }
 
 
+    /**
+     * 게시글을 수정합니다.
+     *
+     * @param updatePostDto 게시글 수정에 필요한 데이터
+     * @param files 첨부 파일 리스트
+     * @param tags 태그 리스트
+     * @param userId 사용자 ID
+     * @param postId 게시글 ID
+     * @return 수정된 게시글의 응답 데이터
+     */
     @Transactional
     public PostDto.PostResponse update(@Valid PostDto.UpdatePostDto updatePostDto, List<MultipartFile> files, List<String> tags, String userId, long postId) {
 
@@ -107,6 +129,12 @@ public class PostService {
         return PostDto.PostResponse.fromPost(upatedPost, List.of(), postImageUrlList);
     }
 
+    /**
+     * 게시글을 삭제합니다.
+     *
+     * @param postId 게시글 ID
+     * @param userId 사용자 ID
+     */
     @Transactional
     public void delete(long postId, String userId) {
         Post post = postQueryMapper.findPostById(postId).orElseThrow(NotExistPostException::new);
@@ -117,6 +145,12 @@ public class PostService {
         postCommandMapper.deleteByPostId(post);
     }
 
+    /**
+     * 게시글 ID로 게시글과 댓글, 파일 정보를 조회합니다.
+     *
+     * @param postId 게시글 ID
+     * @return 게시글 응답 데이터
+     */
     @Transactional
     public PostDto.PostResponse getPostByIdWithCommentsAndFiles(long postId) {
 
@@ -141,6 +175,12 @@ public class PostService {
     }
 
 
+    /**
+     * 게시글 리스트를 조회합니다.
+     *
+     * @param params 검색 조건
+     * @return 페이징 처리된 게시글 리스트 응답 데이터
+     */
     @Transactional(readOnly = true)
     public PagingResponse<PostDto.PostListDto> getPostList(SearchDto params) {
 
@@ -172,6 +212,12 @@ public class PostService {
         return new PagingResponse<>(postListDtos, pagination);
     }
 
+    /**
+     * 인기 게시글 리스트를 조회합니다.
+     *
+     * @param params 검색 조건
+     * @return 페이징 처리된 인기 게시글 리스트 응답 데이터
+     */
     @Transactional(readOnly = true)
     public PagingResponse<PostDto.PostListDto> getPopularPosts(SearchDto params) {
         params.setIsPopular(true); // 인기글만 조회하도록 설정
@@ -179,12 +225,55 @@ public class PostService {
         return getPostList(params); // 기존 getPostList 메서드 호출
     }
 
+    /**
+     * 특정 태그로 게시글을 조회합니다.
+     *
+     * @param tagName 태그 이름
+     * @param params 검색 조건
+     * @return 페이징 처리된 태그 기반 게시글 리스트 응답 데이터
+     */
+    @Transactional(readOnly = true)
+    public PagingResponse<PostDto.PostListDto> getPostsByTag(String tagName, SearchDto params) {
+        int tagId = tagQueryMapper.findTagIdByName(tagName);
+
+        int count = postQueryMapper.countPostsByTagId(tagId);
+        if (count < 1) {
+            return new PagingResponse<>(Collections.emptyList(), null);
+        }
+
+        Pagination pagination = new Pagination(count, params);
+        params.setPagination(pagination);
+
+        List<Post> posts = postQueryMapper.findPostsByTagId(tagId);
+        List<PostDto.PostListDto> postListDtos = posts.stream()
+                .map(PostDto.PostListDto::of)
+                .collect(Collectors.toList());
+
+        return new PagingResponse<>(postListDtos, pagination);
+    }
+
+    /**
+     * 게시글 작성자를 검증합니다.
+     *
+     * @param post 게시글 정보
+     * @param userId 검증할 사용자 ID
+     */
     private void validateWriter(Post post, String userId) {
         if (!post.getUserId().equals(userId)) {
             throw new NotAuthenticationException(userId);
         }
     }
 
+    /**
+     * 주어진 태그 리스트에 대해 새로운 태그를 등록하고, 해당 태그를 게시글에 연결하는 메서드입니다.
+     *
+     * 1. 태그 리스트가 비어있거나 null일 경우 아무 작업도 수행하지 않습니다.
+     * 2. 기존에 존재하는 태그를 조회하고, 새로 추가할 태그들만 필터링하여 등록합니다.
+     * 3. 태그 이름에 해당하는 태그 ID를 조회한 후, 게시글에 해당 태그들을 연결합니다.
+     *
+     * @param tags 게시글에 추가할 태그들의 리스트. null 또는 비어있는 리스트는 처리되지 않습니다.
+     * @param post 태그를 등록할 게시글. 해당 게시글에 태그를 연결합니다.
+     */
     private void registerTag(List<String> tags, Post post) {
 
         if (tags == null || tags.isEmpty()) {

--- a/module-domain/src/main/java/com/study/domain/mapper/post/PostQueryMapper.java
+++ b/module-domain/src/main/java/com/study/domain/mapper/post/PostQueryMapper.java
@@ -7,14 +7,58 @@ import org.apache.ibatis.annotations.Mapper;
 import java.util.List;
 import java.util.Optional;
 
+/**
+ * PostQueryMapper는 게시물과 관련된 데이터베이스 조회 작업을 수행하는 MyBatis 매퍼 인터페이스입니다.
+ * 게시물 정보를 ID로 조회하거나, 특정 태그와 관련된 게시물들을 조회하는 등의 기능을 제공합니다.
+ */
 @Mapper
 public interface PostQueryMapper {
 
+    /**
+     * 주어진 게시물 ID에 대해 해당 게시물을 조회합니다.
+     *
+     * @param id 조회할 게시물의 ID
+     * @return 주어진 게시물 ID에 해당하는 {@link Post} 객체, 없으면 빈 {@link Optional}
+     */
     Optional<Post> findPostById(long id);
 
+    /**
+     * 주어진 게시물 ID에 대해 해당 게시물에 포함된 파일 URL들을 조회합니다.
+     *
+     * @param postId 조회할 게시물의 ID
+     * @return 해당 게시물에 포함된 파일 URL 목록
+     */
     List<String> findFileUrlsByPostId(long postId);
 
+    /**
+     * 주어진 검색 파라미터를 기반으로 게시물 목록을 조회합니다.
+     *
+     * @param params 검색 파라미터 {@link SearchDto}
+     * @return 검색 조건에 맞는 게시물 목록
+     */
     List<Post> findAll(SearchDto params);
 
+    /**
+     * 주어진 검색 파라미터를 기반으로 게시물의 총 개수를 조회합니다.
+     *
+     * @param params 검색 파라미터 {@link SearchDto}
+     * @return 검색 조건에 맞는 게시물의 개수
+     */
     int count(SearchDto params);
+
+    /**
+     * 주어진 태그 ID에 해당하는 게시물 목록을 조회합니다.
+     *
+     * @param tagId 조회할 태그의 ID
+     * @return 주어진 태그 ID와 관련된 게시물 목록
+     */
+    List<Post> findPostsByTagId(int tagId);
+
+    /**
+     * 주어진 태그 ID에 해당하는 게시물의 총 개수를 조회합니다.
+     *
+     * @param tagId 조회할 태그의 ID
+     * @return 주어진 태그 ID와 관련된 게시물의 개수
+     */
+    int countPostsByTagId(int tagId);
 }

--- a/module-domain/src/main/java/com/study/domain/mapper/tag/TagQueryMapper.java
+++ b/module-domain/src/main/java/com/study/domain/mapper/tag/TagQueryMapper.java
@@ -4,11 +4,34 @@ import org.apache.ibatis.annotations.Mapper;
 
 import java.util.List;
 
+/**
+ * TagQueryMapper는 태그 관련 데이터베이스 조회 작업을 수행하는 MyBatis 매퍼 인터페이스입니다.
+ * 태그의 ID를 이름으로 조회하거나, 주어진 태그들에 대한 기존 태그 이름을 확인하는 메서드를 제공합니다.
+ */
 @Mapper
 public interface TagQueryMapper {
 
+    /**
+     * 주어진 태그 이름 목록에 대해 해당하는 태그 ID 목록을 조회합니다.
+     *
+     * @param tags 태그 이름 목록
+     * @return 태그 이름에 해당하는 ID 목록
+     */
     List<Integer> findTagIdsByNames(List<String> tags);
 
+    /**
+     * 주어진 태그 이름 목록에 대해 데이터베이스에 존재하는 태그 이름 목록을 조회합니다.
+     *
+     * @param tags 확인할 태그 이름 목록
+     * @return 데이터베이스에 존재하는 태그 이름 목록
+     */
     List<String> findExistingTagNames(List<String> tags);
 
+    /**
+     * 주어진 태그 이름에 대해 해당하는 태그 ID를 조회합니다.
+     *
+     * @param tagName 조회할 태그 이름
+     * @return 주어진 태그 이름에 해당하는 태그 ID
+     */
+    int findTagIdByName(String tagName);
 }

--- a/module-domain/src/main/resources/mybatis/mapper/post/PostQueryMapper.xml
+++ b/module-domain/src/main/resources/mybatis/mapper/post/PostQueryMapper.xml
@@ -71,4 +71,24 @@
             OR nickName LIKE CONCAT ('%', #{keyword}, '%'))
         </if>
     </select>
+
+    <!-- 태그 id로 게시글 조회 -->
+    <select id="findPostsByTagId" resultType="com.study.domain.post.entity.Post">
+        SELECT p.*
+        FROM post p
+                JOIN posttag pt ON p.id = pt.post_id
+        WHERE
+            pt.tag_id = #{tagId}
+        ORDER BY
+            p.id DESC
+        LIMIT #{pagination.limitStart}, #{recordSize}
+    </select>
+
+    <!-- 태그 검색 게시글 수 카운팅 -->
+    <select id="countPostsByTagId" resultType="int">
+        SELECT COUNT(*)
+        FROM post p
+                 JOIN posttag pt ON p.id = pt.post_Id
+        WHERE pt.tag_Id = #{tagId}
+    </select>
 </mapper>

--- a/module-domain/src/main/resources/mybatis/mapper/tag/TagQueryMapper.xml
+++ b/module-domain/src/main/resources/mybatis/mapper/tag/TagQueryMapper.xml
@@ -21,4 +21,9 @@
         </foreach>
     </select>
 
+    <select id="findTagIdByName" resultType="int">
+        SELECT id
+        FROM tag
+        WHERE tagName = #{tagName}
+    </select>
 </mapper>


### PR DESCRIPTION
> - #32 

### 작업 내용 요약
- [x] 주어진 태그 ID에 해당하는 게시물의 총 개수를 조회한다.
- [x] 주어진 태그 ID에 해당하는 게시물 목록을 조회한다.
- [x] 주어진 태그 이름에 해당하는 태그 ID를 조회한다.
- [x] 주어진 태그로 게시글을 검색하고 페이징하는 서비스로직을 구현한다.
- [x] PostController에 동일한 태그가 달린 게시글 리스트를 가지고 오는 API를 추가한다.

### 작업 상세 내용
## PostQueryMapper 파일
- **PostQueryMapper** 인터페이스에 태그ID로 해당하는 태그를 가진 게시글과 그 게시글의 개수를 찾는 추상메서드를 정의한다. 그리고 **PostQueryMapper.xml** 에서 메서드를 구현한다.  
![image](https://github.com/user-attachments/assets/5e37429c-4297-4bb2-afd5-9a37db434069)
- `posttag 테이블`에서 해당하는 태그 ID에 연결된 post_id를 찾고, 찾은 post_id를 이용해 post 테이블에서 게시글 데이터를 조회하기위한 join을 사용한다. 
- 태그를 가진 게시글의 수를 찾을 때도 마찬가지이다. 이렇게 찾은 게시글의 개수는 페이징을 할 때 사용된다.
![image](https://github.com/user-attachments/assets/f10a0d48-0ebe-4a0a-a118-9a02b5724249)

## TagQueryMapper 파일
- **TagQueryMapper** 인터페이스에 주어진 태그 이름에 해당하는 태그 ID를 조회하는 추상메서드를 정의한다. 그리고 **TagQueryMapper.xml** 에서 메서드를 구현한다.   
![image](https://github.com/user-attachments/assets/cab7a2f4-7717-4bf3-9376-cc077ff958cb)
- 입력받은 태그로 태그ID를 찾고 posttag 테이블에서 해당하는 태그ID를 가지고 있는 PostID를 찾은 후, Post를 찾기 위해 사용한다. 
![image](https://github.com/user-attachments/assets/2952ffe6-a957-4319-937c-a54b0ecfcaab)

## PostService 파일
![image](https://github.com/user-attachments/assets/39b86980-c0aa-4dd6-82c9-9a1173cae4e1)
- `findTagIdByName`와 `countPostsByTagId` 메서드를 사용해서 태그 ID를 조회하고 조회한 태그 ID에 연결된 게시글의 총 개수를 계산한다.
- count가 0보다 작거나 같은 경우, 해당 태그에 연결된 게시글이 없는 것으로, 이 경우 빈 게시글 목록과 페이징 정보 없이 반환한다.
`if (count < 1) {
    return new PagingResponse<>(Collections.emptyList(), null);
}`
- 게시글 수(count)와 SearchDto의 페이징 조건(page, size)을 기반으로 페이징 객체를 생성한다.
`Pagination pagination = new Pagination(count, params);`
`params.setPagination(pagination);`

- `findPostsByTagId` 메서드를 사용해서 데이터베이스에서 해당 태그에 연결된 게시글 목록을 조회한다.
`List<Post> posts = postQueryMapper.findPostsByTagId(tagId);`

- 조회된 게시글 리스트(posts)를 DTO 객체(PostListDto)로 변환한다.
`List<PostDto.PostListDto> postListDtos = posts.stream()`
`.map(PostDto.PostListDto::of)`
`.collect(Collectors.toList());`

## PostController
![image](https://github.com/user-attachments/assets/1021a36d-00c0-4b58-b375-cb37414fc47c)
- `tagName`은 경로변수로, 검색 및 페이징 조건을 담은 객체인 `SearchDto`를 받는다. 게시글 리스트를 HTTP 응답 객체를 래핑하여 반환하는 API이다.



